### PR TITLE
Turn bare procedure calls into CALL statements

### DIFF
--- a/src/pgrecon/convert/code.py
+++ b/src/pgrecon/convert/code.py
@@ -299,6 +299,10 @@ def _emit_code(
             "SELECT name FROM objects WHERE type IN ('FUNCTION', 'PROCEDURE')"
         )
     }
+    procedures = frozenset(
+        (r["name"] or "").upper()
+        for r in conn.execute("SELECT name FROM objects WHERE type = 'PROCEDURE'")
+    )
     packages = {
         (r["name"] or "").upper()
         for r in conn.execute("SELECT name FROM objects WHERE type = 'PACKAGE'")
@@ -397,7 +401,7 @@ def _emit_code(
         if not reasons:
             text = _unit_text(conn, owner, name, otype)
             relations = tables | created_views | synonyms
-            result = rewrite_unit(text, otype, sequences, relations)
+            result = rewrite_unit(text, otype, sequences, relations, procedures)
             reasons += list(result.reasons)
             notes += list(result.notes)
             sql = result.sql

--- a/src/pgrecon/convert/plsql_rewrite.py
+++ b/src/pgrecon/convert/plsql_rewrite.py
@@ -71,11 +71,13 @@ class _Rewriter(PlSqlParserListener):  # type: ignore[misc]
         is_function: bool,
         sequences: set[str],
         relations: set[str],
+        procedures: frozenset[str],
     ) -> None:
         self.text = text
         self.is_function = is_function
         self.sequences = sequences
         self.relations = relations
+        self.procedures = procedures
         self.edits: list[tuple[int, int, str]] = []
         self.reasons: list[str] = []
         self.notes: list[str] = []
@@ -428,6 +430,15 @@ class _Rewriter(PlSqlParserListener):  # type: ignore[misc]
                 "RAISE_APPLICATION_ERROR carries an Oracle error code;"
                 " choose a RAISE EXCEPTION ... USING ERRCODE mapping",
             )
+        elif callee.replace('"', "") in self.procedures:
+            # A bare procedure-call statement is not a statement on
+            # PostgreSQL; it becomes CALL, with the parentheses CALL
+            # requires.
+            spelled = _fold_written(self._span_text(routine))
+            if args is None:
+                self._edit_ctx(routine, f"CALL {spelled}()")
+            else:
+                self._edit_ctx(routine, f"CALL {spelled}")
 
     def enterException_handler(self, ctx: Any) -> None:
         for name in ctx.exception_name():
@@ -674,21 +685,28 @@ def _apply(text: str, edits: list[tuple[int, int, str]]) -> str | None:
 
 
 def rewrite_unit(
-    text: str, unit_type: str, sequences: set[str], relations: set[str]
+    text: str,
+    unit_type: str,
+    sequences: set[str],
+    relations: set[str],
+    procedures: frozenset[str] = frozenset(),
 ) -> RewriteResult:
     """One stored FUNCTION or PROCEDURE as PostgreSQL DDL, or reasons.
 
     The input is the unit exactly as ALL_SOURCE stored it, starting at
     its type keyword; the output is a complete CREATE OR REPLACE
     statement in dollar quoting, or None with every reason the unit
-    was refused.
+    was refused. Callees named in procedures are procedure-call
+    statements on the source side and gain the CALL PostgreSQL needs.
     """
     parse = parse_source(text.rstrip())
     if parse.tree is None or parse.errors:
         first = parse.errors[0] if parse.errors else "no parse tree"
         return RewriteResult(None, (f"did not parse cleanly ({first})",), ())
     full = "CREATE OR REPLACE " + text.rstrip()
-    rewriter = _Rewriter(full, unit_type.upper() == "FUNCTION", sequences, relations)
+    rewriter = _Rewriter(
+        full, unit_type.upper() == "FUNCTION", sequences, relations, procedures
+    )
     ParseTreeWalker.DEFAULT.walk(rewriter, parse.tree)
     _scan_tokens(rewriter, parse.tokens)
     notes = tuple(dict.fromkeys(rewriter.notes))

--- a/tests/test_convert_code.py
+++ b/tests/test_convert_code.py
@@ -157,6 +157,13 @@ BEGIN
   EXECUTE IMMEDIATE 'begin :x := 1; end;' USING OUT p;
 END binds_out_p;"""
 
+PCALL_P = """PROCEDURE pcall_p IS
+  v NUMBER := 1;
+BEGIN
+  p_commit;
+  inout_p(v);
+END pcall_p;"""
+
 _UNITS = [
     ("FEE_FOR", "FUNCTION", FEE_FOR),
     ("AUTON_P", "PROCEDURE", AUTON_P),
@@ -177,6 +184,7 @@ _UNITS = [
     ("BINDS_P", "PROCEDURE", BINDS_P),
     ("BINDS_LOOSE_P", "PROCEDURE", BINDS_LOOSE_P),
     ("BINDS_OUT_P", "PROCEDURE", BINDS_OUT_P),
+    ("PCALL_P", "PROCEDURE", PCALL_P),
 ]
 
 
@@ -310,8 +318,14 @@ def test_refusal_cascades_to_callers(code_db: Path) -> None:
 
 def test_routine_count_matches_emitted(code_db: Path) -> None:
     result = convert_schema(code_db)
-    assert result.routines == 7
-    assert result.sql.count("LANGUAGE plpgsql") == 7
+    assert result.routines == 8
+    assert result.sql.count("LANGUAGE plpgsql") == 8
+
+
+def test_bare_procedure_calls_gain_call(code_db: Path) -> None:
+    result = convert_schema(code_db)
+    assert "CALL p_commit();" in result.sql
+    assert "CALL inout_p(v);" in result.sql
 
 
 def test_adjacent_fetch_notfound_translates(code_db: Path) -> None:


### PR DESCRIPTION
A procedure invoked as a bare statement is not a statement on PostgreSQL. Call sites whose callee is a known procedure gain CALL and the parentheses CALL requires; rewrite_unit takes the procedure set as a parameter so downstream tooling can extend it with schema-qualified names.