### PR TITLE
Convert simple DML triggers to trigger functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
 
+## Unreleased
+
+- Triggers convert: a simple DML trigger becomes a trigger function
+  plus the CREATE TRIGGER statement PostgreSQL wants. :NEW and :OLD
+  lose their colons, INSERTING/UPDATING/DELETING become TG_OP tests,
+  bare RETURN gains the row result, UPDATE OF column lists survive
+  from the parse tree, WHEN clauses translate through the same
+  folding as views, and disabled triggers stay disabled via ALTER
+  TABLE. Compound triggers, INSTEAD OF, system triggers, and
+  UPDATING('column') refuse by name; sequence-fed triggers convert
+  and carry a note pointing at generated identity columns.
+
 ## 0.2.1 - 2026-08-19
 
 - Bare procedure-call statements become CALL statements with the

--- a/src/pgrecon/cli.py
+++ b/src/pgrecon/cli.py
@@ -301,7 +301,7 @@ def convert(
         f" children, {result.constraints} constraints, {result.indexes} indexes,"
         f" {result.views} views, {result.sequences} sequences,"
         f" {result.synonyms} synonyms, {result.db_links} db links,"
-        f" {result.routines} routines)"
+        f" {result.routines} routines, {result.triggers} triggers)"
     )
     typer.echo(f"Wrote {residue} ({len(result.residue)} residue items)")
 

--- a/src/pgrecon/convert/code.py
+++ b/src/pgrecon/convert/code.py
@@ -323,18 +323,6 @@ def _emit_code(
             )
         )
     for r in conn.execute(
-        "SELECT owner, trigger_name FROM triggers ORDER BY owner, trigger_name"
-    ):
-        residue.append(
-            Residue(
-                r["owner"],
-                r["trigger_name"],
-                "trigger",
-                "a trigger becomes a trigger function plus a CREATE"
-                " TRIGGER statement; port it by hand",
-            )
-        )
-    for r in conn.execute(
         "SELECT owner, name FROM objects WHERE type = 'TYPE' ORDER BY owner, name"
     ):
         residue.append(

--- a/src/pgrecon/convert/schema.py
+++ b/src/pgrecon/convert/schema.py
@@ -22,6 +22,7 @@ from pgrecon.convert.identifiers import ident as ident
 from pgrecon.convert.indexes import _emit_indexes
 from pgrecon.convert.residue import Residue as Residue
 from pgrecon.convert.tables import emit_tables
+from pgrecon.convert.triggers import _emit_triggers
 from pgrecon.convert.views import _emit_views
 
 
@@ -38,6 +39,7 @@ class Conversion:
     synonyms: int
     db_links: int
     routines: int
+    triggers: int
 
 
 def convert_schema(db: Path) -> Conversion:
@@ -83,6 +85,32 @@ def _convert(conn: sqlite3.Connection) -> Conversion:
     routine_count = _emit_code(
         conn, out, residue, emitted, created_views, sequence_names, synonym_names
     )
+    trigger_count = _emit_triggers(
+        conn,
+        out,
+        residue,
+        emitted,
+        sequence_names,
+        {t for (_, t) in emitted} | created_views | synonym_names,
+        frozenset(
+            (r["name"] or "").upper()
+            for r in conn.execute("SELECT name FROM objects WHERE type = 'PROCEDURE'")
+        ),
+        {
+            (r["owner"] or "").upper()
+            for r in conn.execute("SELECT DISTINCT owner FROM objects")
+        },
+        {
+            (r["name"] or "").upper()
+            for r in conn.execute(
+                "SELECT name FROM objects WHERE type IN ('FUNCTION', 'PROCEDURE')"
+            )
+        },
+        {
+            (r["name"] or "").upper()
+            for r in conn.execute("SELECT name FROM objects WHERE type = 'PACKAGE'")
+        },
+    )
     link_count = _emit_db_links(conn, out, residue)
 
     return Conversion(
@@ -97,6 +125,7 @@ def _convert(conn: sqlite3.Connection) -> Conversion:
         synonym_count,
         link_count,
         routine_count,
+        trigger_count,
     )
 
 

--- a/src/pgrecon/convert/triggers.py
+++ b/src/pgrecon/convert/triggers.py
@@ -1,0 +1,333 @@
+"""Trigger emission: the body through the mechanical rewriter, paired
+with the CREATE TRIGGER statement PostgreSQL wants.
+
+A simple DML trigger maps mechanically: the block becomes a trigger
+function, :NEW and :OLD lose their colons, the event predicates
+become TG_OP tests, and the header is rebuilt from the parse tree so
+UPDATE OF column lists survive. Everything else - compound triggers,
+system triggers, INSTEAD OF, UPDATING('col') - refuses by name.
+"""
+
+import sqlite3
+from typing import Any
+
+from pgrecon.convert.code import (
+    _call_gate,
+    _dependency_gate,
+    _feature_gate,
+    _unit_text,
+)
+from pgrecon.convert.identifiers import _fold_condition
+from pgrecon.convert.plsql_rewrite import (
+    _apply,
+    _first_descendant,
+    _fold_written,
+    rewrite_unit,
+)
+from pgrecon.convert.residue import Residue
+from pgrecon.plsql import parse_source
+from pgrecon.plsql._generated.PlSqlLexer import PlSqlLexer as L
+
+_PREDICATES = {
+    "INSERTING": "(TG_OP = 'INSERT')",
+    "UPDATING": "(TG_OP = 'UPDATE')",
+    "DELETING": "(TG_OP = 'DELETE')",
+}
+
+
+def _tree_of(ctx: Any, name: str) -> Any | None:
+    return _first_descendant(ctx, name)
+
+
+def _walk_all(node: Any, name: str) -> list[Any]:
+    found = []
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        for i in range(current.getChildCount()):
+            child = current.getChild(i)
+            if not hasattr(child, "getChildCount"):
+                continue
+            if type(child).__name__.replace("Context", "") == name:
+                found.append(child)
+            stack.append(child)
+    return found
+
+
+def _span(text: str, ctx: Any) -> str:
+    return text[ctx.start.start : ctx.stop.stop + 1]
+
+
+def _trigger_function(
+    text: str,
+    tree: Any,
+    tokens: Any,
+    fn_name: str,
+    row_level: bool,
+    sequences: set[str],
+    relations: set[str],
+    procedures: frozenset[str],
+) -> tuple[str | None, list[str], list[str]]:
+    """The trigger block as a PostgreSQL trigger function."""
+    block = _tree_of(tree, "Trigger_block")
+    if block is None:
+        return None, ["the trigger body shape is not a plain block"], []
+    start, stop = block.start.start, block.stop.stop
+    stream = [t for t in tokens.tokens if t.channel == 0]
+    edits: list[tuple[int, int, str]] = []
+    reasons: list[str] = []
+    fallthrough = "COALESCE(NEW, OLD)" if row_level else "NULL"
+
+    for i, tok in enumerate(stream):
+        if not (start <= tok.start <= stop):
+            continue
+        upper = (tok.text or "").upper()
+        nxt = stream[i + 1] if i + 1 < len(stream) else None
+        if upper in (":NEW", ":OLD"):
+            edits.append((tok.start, tok.stop, upper[1:]))
+        elif upper in _PREDICATES:
+            if nxt is not None and nxt.type == L.LEFT_PAREN:
+                reasons.append(
+                    f"{upper}('column') tests which columns the UPDATE"
+                    " names; PostgreSQL has no counterpart - rewrite by hand"
+                )
+            else:
+                edits.append((tok.start, tok.stop, _PREDICATES[upper]))
+        elif tok.type == L.DECLARE and tok.start == start:
+            edits.append((tok.start, tok.stop, ""))
+
+    for statement in _walk_all(block, "Return_statement"):
+        if statement.getChildCount() == 1:
+            edits.append(
+                (statement.start.start, statement.stop.stop, f"RETURN {fallthrough}")
+            )
+
+    last_end = next(
+        (t for t in reversed(stream) if t.type == L.END and start <= t.start <= stop),
+        None,
+    )
+    if last_end is None:
+        return None, ["the trigger body has no closing END"], []
+    edits.append((last_end.start, last_end.stop, f"RETURN {fallthrough};\nEND"))
+
+    if reasons:
+        return None, reasons, []
+    shifted = [(s - start, e - start, r) for s, e, r in edits]
+    body = _apply(text[start : stop + 1], shifted)
+    if body is None:
+        return None, ["trigger rewrites collided; port it by hand"], []
+    result = rewrite_unit(
+        f"PROCEDURE {fn_name} IS\n{body}", "PROCEDURE", sequences, relations, procedures
+    )
+    if result.sql is None:
+        return None, list(result.reasons), list(result.notes)
+    sql = result.sql.replace(
+        f"CREATE OR REPLACE PROCEDURE {fn_name}()",
+        f"CREATE OR REPLACE FUNCTION {fn_name}() RETURNS trigger",
+        1,
+    )
+    return sql, [], list(result.notes)
+
+
+def _emit_triggers(
+    conn: sqlite3.Connection,
+    out: list[str],
+    residue: list[Residue],
+    emitted: dict[tuple[str, str], set[str]],
+    sequences: set[str],
+    relations: set[str],
+    procedures: frozenset[str],
+    owners: set[str],
+    callables: set[str],
+    packages: set[str],
+) -> int:
+    count = 0
+    rows = conn.execute(
+        "SELECT owner, trigger_name, trigger_type, status FROM triggers"
+        " ORDER BY owner, trigger_name"
+    ).fetchall()
+    tables = {t for (_, t) in emitted}
+    for r in rows:
+        owner, name = r["owner"], r["trigger_name"]
+        kind = (r["trigger_type"] or "").upper()
+        if "COMPOUND" in kind:
+            residue.append(
+                Residue(
+                    owner,
+                    name,
+                    "trigger",
+                    "compound triggers combine timing points; restructure"
+                    " as separate triggers by hand",
+                )
+            )
+            continue
+        if "INSTEAD OF" in kind:
+            residue.append(
+                Residue(
+                    owner,
+                    name,
+                    "trigger",
+                    "INSTEAD OF triggers need the view and its update"
+                    " semantics reviewed; port by hand",
+                )
+            )
+            continue
+        unit = conn.execute(
+            "SELECT parse_mode, error_count, first_error FROM plsql_units"
+            " WHERE owner = ? AND name = ? AND type = 'TRIGGER'",
+            (owner, name),
+        ).fetchone()
+        if unit is None or unit["parse_mode"] in ("wrapped", "generated"):
+            residue.append(
+                Residue(
+                    owner,
+                    name,
+                    "trigger",
+                    "no parseable trigger source was extracted",
+                )
+            )
+            continue
+        if unit["error_count"]:
+            residue.append(
+                Residue(
+                    owner,
+                    name,
+                    "trigger",
+                    f"did not parse cleanly ({unit['first_error']}); port it by hand",
+                )
+            )
+            continue
+        reasons, notes = _feature_gate(conn, owner, name, "TRIGGER")
+        call_reasons, _ = _call_gate(
+            conn, owner, name, "TRIGGER", owners, callables, packages
+        )
+        # The event predicates parse as calls when they carry a column
+        # argument; the body rewriter names that case precisely.
+        call_reasons = [
+            x
+            for x in call_reasons
+            if not any(
+                f"calls {p}," in x for p in ("INSERTING", "UPDATING", "DELETING")
+            )
+        ]
+        dep_reasons, _ = _dependency_gate(
+            conn, owner, name, "TRIGGER", owners, tables, set(), sequences, set()
+        )
+        reasons += call_reasons + dep_reasons
+        if reasons:
+            residue.append(Residue(owner, name, "trigger", "; ".join(reasons[:3])))
+            continue
+
+        text = "CREATE OR REPLACE " + _unit_text(conn, owner, name, "TRIGGER").rstrip()
+        parse = parse_source(_unit_text(conn, owner, name, "TRIGGER").rstrip())
+        if parse.tree is None or parse.errors:
+            residue.append(
+                Residue(owner, name, "trigger", "trigger source did not re-parse")
+            )
+            continue
+        simple = _tree_of(parse.tree, "Simple_dml_trigger")
+        if simple is None:
+            residue.append(
+                Residue(
+                    owner,
+                    name,
+                    "trigger",
+                    "only simple DML triggers convert mechanically;"
+                    " port this shape by hand",
+                )
+            )
+            continue
+        event_clause = _tree_of(simple, "Dml_event_clause")
+        table_ctx = (
+            _tree_of(event_clause, "Tableview_name")
+            if event_clause is not None
+            else None
+        )
+        if event_clause is None or table_ctx is None:
+            residue.append(
+                Residue(owner, name, "trigger", "the trigger header did not dissect")
+            )
+            continue
+        table = _fold_written(_span(text, table_ctx)).lower()
+        if table.upper() not in tables:
+            residue.append(
+                Residue(
+                    owner,
+                    name,
+                    "trigger",
+                    f"its table {table.upper()} is not in the converted set",
+                )
+            )
+            continue
+        events = " OR ".join(
+            " ".join(_span(text, e).lower().split())
+            for e in _walk_all(event_clause, "Dml_event_element")
+        )
+        timing = "BEFORE"
+        for i in range(simple.getChildCount()):
+            child = simple.getChild(i)
+            symbol = getattr(child, "symbol", None)
+            if symbol is not None and symbol.type == L.AFTER:
+                timing = "AFTER"
+        row_level = _tree_of(simple, "For_each_row") is not None
+
+        when_sql = ""
+        when = _tree_of(parse.tree, "Trigger_when_clause")
+        if when is not None:
+            condition = _tree_of(when, "Condition")
+            folded = (
+                _fold_condition(_span(text, condition))
+                if condition is not None
+                else None
+            )
+            if folded is None:
+                residue.append(
+                    Residue(
+                        owner,
+                        name,
+                        "trigger",
+                        "the WHEN condition could not be translated; port it by hand",
+                    )
+                )
+                continue
+            when_sql = f" WHEN ({folded})"
+
+        fn_name = f"{name.lower()}_fn"
+        fn_sql, fn_reasons, fn_notes = _trigger_function(
+            text,
+            parse.tree,
+            parse.tokens,
+            fn_name,
+            row_level,
+            sequences,
+            relations,
+            procedures,
+        )
+        if fn_sql is None:
+            residue.append(Residue(owner, name, "trigger", "; ".join(fn_reasons[:3])))
+            continue
+        out.append(fn_sql)
+        out.append("")
+        level = "FOR EACH ROW" if row_level else "FOR EACH STATEMENT"
+        out.append(
+            f"CREATE TRIGGER {name.lower()} {timing} {events} ON {table}\n"
+            f"{level}{when_sql}\n"
+            f"EXECUTE FUNCTION {fn_name}();"
+        )
+        if (r["status"] or "").upper() == "DISABLED":
+            out.append(f"ALTER TABLE {table} DISABLE TRIGGER {name.lower()};")
+        out.append("")
+        for note in fn_notes:
+            residue.append(Residue(owner, name, "note", note))
+        if "nextval(" in fn_sql:
+            residue.append(
+                Residue(
+                    owner,
+                    name,
+                    "note",
+                    "sequence-fed trigger; a generated identity column is"
+                    " the modern PostgreSQL shape for this",
+                )
+            )
+        count += 1
+    return count

--- a/tests/test_convert_triggers.py
+++ b/tests/test_convert_triggers.py
@@ -1,0 +1,187 @@
+"""Trigger conversion: paired trigger functions and honest refusals."""
+
+from pathlib import Path
+
+import pytest
+
+from pgrecon.convert import convert_schema
+from pgrecon.inventory import open_db
+from pgrecon.inventory.loader import _analyze_plsql
+
+TRG_STAMP = """TRIGGER trg_stamp
+BEFORE INSERT OR UPDATE ON t_fees
+FOR EACH ROW
+WHEN (new.fee > 0)
+DECLARE
+  v_tag VARCHAR2(10);
+BEGIN
+  IF INSERTING THEN
+    :NEW.tag := 'ins';
+  END IF;
+  IF UPDATING THEN
+    RETURN;
+  END IF;
+  :NEW.fee := NVL(:NEW.fee, 0);
+END;"""
+
+TRG_SEQ = """TRIGGER trg_seq
+BEFORE INSERT ON t_fees
+FOR EACH ROW
+BEGIN
+  :NEW.fee := ref_seq.NEXTVAL;
+END;"""
+
+TRG_STMT = """TRIGGER trg_stmt
+AFTER INSERT ON t_fees
+BEGIN
+  INSERT INTO audit_log (audit_id) VALUES (1);
+END;"""
+
+TRG_UPDOF = """TRIGGER trg_updof
+BEFORE UPDATE OF fee ON t_fees
+FOR EACH ROW
+BEGIN
+  :NEW.tag := 'u';
+END;"""
+
+TRG_BAD = """TRIGGER trg_bad
+BEFORE UPDATE ON t_fees
+FOR EACH ROW
+BEGIN
+  IF UPDATING('fee') THEN
+    :NEW.tag := 'x';
+  END IF;
+END;"""
+
+TRG_DIS = """TRIGGER trg_dis
+BEFORE INSERT ON t_fees
+FOR EACH ROW
+BEGIN
+  :NEW.tag := 'd';
+END;"""
+
+_TRIGGERS = [
+    ("TRG_STAMP", "BEFORE EACH ROW", "INSERT OR UPDATE", "ENABLED", TRG_STAMP),
+    ("TRG_SEQ", "BEFORE EACH ROW", "INSERT", "ENABLED", TRG_SEQ),
+    ("TRG_STMT", "AFTER STATEMENT", "INSERT", "ENABLED", TRG_STMT),
+    ("TRG_UPDOF", "BEFORE EACH ROW", "UPDATE", "ENABLED", TRG_UPDOF),
+    ("TRG_BAD", "BEFORE EACH ROW", "UPDATE", "ENABLED", TRG_BAD),
+    ("TRG_DIS", "BEFORE EACH ROW", "INSERT", "DISABLED", TRG_DIS),
+]
+
+
+@pytest.fixture
+def trigger_db(tmp_path: Path) -> Path:
+    db = tmp_path / "triggers.db"
+    conn = open_db(db)
+    conn.executescript(
+        """
+        INSERT INTO objects VALUES ('AX', 'T_FEES', 'TABLE', 'VALID', NULL, NULL);
+        INSERT INTO objects VALUES ('AX', 'AUDIT_LOG', 'TABLE', 'VALID', NULL, NULL);
+        INSERT INTO tables (owner, table_name) VALUES ('AX', 'T_FEES');
+        INSERT INTO tables (owner, table_name) VALUES ('AX', 'AUDIT_LOG');
+        INSERT INTO columns VALUES
+            ('AX', 'T_FEES', 'FEE', 1, 'NUMBER', 22, 10, 2, 'Y'),
+            ('AX', 'T_FEES', 'TAG', 2, 'VARCHAR2', 30, NULL, NULL, 'Y'),
+            ('AX', 'AUDIT_LOG', 'AUDIT_ID', 1, 'NUMBER', 22, 10, 0, 'Y');
+        INSERT INTO sequences VALUES
+            ('AX', 'REF_SEQ', '1', '9999999', '1', 'N', '20', '41');
+        INSERT INTO triggers VALUES
+            ('AX', 'TRG_COMP', 'COMPOUND', 'INSERT', 'T_FEES', 'ENABLED');
+        """
+    )
+    for name, ttype, event, status, text in _TRIGGERS:
+        conn.execute(
+            "INSERT INTO triggers VALUES ('AX', ?, ?, ?, 'T_FEES', ?)",
+            (name, ttype, event, status),
+        )
+        conn.execute(
+            "INSERT INTO objects (owner, name, type, status)"
+            " VALUES ('AX', ?, 'TRIGGER', 'VALID')",
+            (name,),
+        )
+        for i, line in enumerate(text.splitlines(keepends=True), start=1):
+            conn.execute(
+                "INSERT INTO source (owner, name, type, line, text)"
+                " VALUES ('AX', ?, 'TRIGGER', ?, ?)",
+                (name, i, line),
+            )
+    _analyze_plsql(conn)
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _reason(result, name: str) -> str:
+    matches = [
+        r.reason
+        for r in result.residue
+        if r.object_name == name and r.kind == "trigger"
+    ]
+    assert matches, f"no trigger residue for {name}"
+    return matches[0]
+
+
+def test_row_trigger_pairs_function_and_trigger(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    sql = result.sql
+    assert "CREATE OR REPLACE FUNCTION trg_stamp_fn() RETURNS trigger" in sql
+    assert "(TG_OP = 'INSERT')" in sql
+    assert "NEW.tag := 'ins';" in sql
+    assert "COALESCE(NEW.fee, 0)" in sql
+    assert ":NEW" not in sql
+    assert "RETURN COALESCE(NEW, OLD);" in sql
+    assert "CREATE TRIGGER trg_stamp BEFORE insert OR update ON t_fees" in sql
+    assert "FOR EACH ROW WHEN (new.fee > 0)" in sql
+    assert "EXECUTE FUNCTION trg_stamp_fn();" in sql
+
+
+def test_bare_return_gains_trigger_result(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    body = result.sql.split("trg_stamp_fn", 2)[1]
+    assert body.count("RETURN COALESCE(NEW, OLD);") == 2
+
+
+def test_sequence_trigger_converts_with_identity_note(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    assert "NEW.fee := nextval('ref_seq');" in result.sql
+    notes = [
+        r.reason
+        for r in result.residue
+        if r.object_name == "TRG_SEQ" and r.kind == "note"
+    ]
+    assert any("identity column" in n for n in notes)
+
+
+def test_statement_trigger_returns_null(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    assert "CREATE TRIGGER trg_stmt AFTER insert ON t_fees" in result.sql
+    assert "FOR EACH STATEMENT" in result.sql
+    body = result.sql.split("trg_stmt_fn", 2)[1]
+    assert "RETURN NULL;" in body
+
+
+def test_update_of_column_list_survives(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    assert "CREATE TRIGGER trg_updof BEFORE update of fee ON t_fees" in result.sql
+
+
+def test_updating_column_predicate_refuses(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    assert "UPDATING('column')" in _reason(result, "TRG_BAD")
+
+
+def test_compound_trigger_refuses(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    assert "compound" in _reason(result, "TRG_COMP")
+
+
+def test_disabled_trigger_stays_disabled(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    assert "ALTER TABLE t_fees DISABLE TRIGGER trg_dis;" in result.sql
+
+
+def test_trigger_count(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    assert result.triggers == 5
+    assert result.sql.count("RETURNS trigger") == 5


### PR DESCRIPTION
The block converts through the same mechanical rewriter as standalone routines and pairs with a rebuilt CREATE TRIGGER: :NEW/:OLD fold, event predicates become TG_OP tests, bare RETURN gains the row result, UPDATE OF column lists survive from the parse tree, WHEN clauses fold like views, and disabled triggers stay disabled. Compound, INSTEAD OF, system triggers, and UPDATING('column') refuse by name. On the AMT_SANITY estate this converts 3 of 4 real triggers.