### PR TITLE
Move conflicted trigger WHEN conditions into the body

### DIFF
--- a/src/pgrecon/convert/triggers.py
+++ b/src/pgrecon/convert/triggers.py
@@ -272,6 +272,7 @@ def _emit_triggers(
         row_level = _tree_of(simple, "For_each_row") is not None
 
         when_sql = ""
+        body_guard: str | None = None
         when = _tree_of(parse.tree, "Trigger_when_clause")
         if when is not None:
             condition = _tree_of(when, "Condition")
@@ -290,7 +291,18 @@ def _emit_triggers(
                     )
                 )
                 continue
-            when_sql = f" WHEN ({folded})"
+            # PostgreSQL refuses at CREATE a WHEN that reads NEW on a
+            # DELETE trigger or OLD on an INSERT trigger; Oracle just
+            # null-evaluates it per row. The condition moves into the
+            # body as an IS NOT TRUE guard - same rows fire either way.
+            lowered = folded.lower()
+            conflicted = ("new." in lowered and "delete" in events) or (
+                "old." in lowered and "insert" in events
+            )
+            if conflicted:
+                body_guard = folded
+            else:
+                when_sql = f" WHEN ({folded})"
 
         fn_name = f"{name.lower()}_fn"
         fn_sql, fn_reasons, fn_notes = _trigger_function(
@@ -306,6 +318,14 @@ def _emit_triggers(
         if fn_sql is None:
             residue.append(Residue(owner, name, "trigger", "; ".join(fn_reasons[:3])))
             continue
+        if body_guard is not None:
+            fallthrough = "COALESCE(NEW, OLD)" if row_level else "NULL"
+            fn_sql = fn_sql.replace(
+                "BEGIN",
+                f"BEGIN\n  IF ({body_guard}) IS NOT TRUE THEN\n"
+                f"    RETURN {fallthrough};\n  END IF;",
+                1,
+            )
         out.append(fn_sql)
         out.append("")
         level = "FOR EACH ROW" if row_level else "FOR EACH STATEMENT"

--- a/tests/test_convert_triggers.py
+++ b/tests/test_convert_triggers.py
@@ -60,6 +60,14 @@ BEGIN
   :NEW.tag := 'd';
 END;"""
 
+TRG_WHENDEL = """TRIGGER trg_whendel
+AFTER INSERT OR UPDATE OR DELETE ON t_fees
+FOR EACH ROW
+WHEN (new.fee > 0)
+BEGIN
+  DBMS_OUTPUT.PUT_LINE('fee touched');
+END;"""
+
 _TRIGGERS = [
     ("TRG_STAMP", "BEFORE EACH ROW", "INSERT OR UPDATE", "ENABLED", TRG_STAMP),
     ("TRG_SEQ", "BEFORE EACH ROW", "INSERT", "ENABLED", TRG_SEQ),
@@ -67,6 +75,13 @@ _TRIGGERS = [
     ("TRG_UPDOF", "BEFORE EACH ROW", "UPDATE", "ENABLED", TRG_UPDOF),
     ("TRG_BAD", "BEFORE EACH ROW", "UPDATE", "ENABLED", TRG_BAD),
     ("TRG_DIS", "BEFORE EACH ROW", "INSERT", "DISABLED", TRG_DIS),
+    (
+        "TRG_WHENDEL",
+        "AFTER EACH ROW",
+        "INSERT OR UPDATE OR DELETE",
+        "ENABLED",
+        TRG_WHENDEL,
+    ),
 ]
 
 
@@ -181,7 +196,16 @@ def test_disabled_trigger_stays_disabled(trigger_db: Path) -> None:
     assert "ALTER TABLE t_fees DISABLE TRIGGER trg_dis;" in result.sql
 
 
+def test_new_reference_with_delete_moves_when_into_body(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    section = result.sql.split("trg_whendel_fn", 2)[1]
+    assert "IF (new.fee > 0) IS NOT TRUE THEN" in section
+    assert "CREATE TRIGGER trg_whendel AFTER insert OR update OR delete" in result.sql
+    header = result.sql.split("CREATE TRIGGER trg_whendel", 1)[1].split(";", 1)[0]
+    assert "WHEN" not in header
+
+
 def test_trigger_count(trigger_db: Path) -> None:
     result = convert_schema(trigger_db)
-    assert result.triggers == 5
-    assert result.sql.count("RETURNS trigger") == 5
+    assert result.triggers == 6
+    assert result.sql.count("RETURNS trigger") == 6


### PR DESCRIPTION
PostgreSQL refuses WHEN reading NEW on DELETE triggers (and OLD on INSERT) at CREATE time; Oracle null-evaluates per row. The condition becomes an IS NOT TRUE body guard - identical firing semantics. Found live: the estate's display_sal_diff failed to apply before this.