### PR TITLE
convert: carry Oracle NULL semantics through concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
 
 ## Unreleased
 
+- Concatenation carries Oracle's NULL semantics: every || chain
+  becomes NULLIF(concat(...), ''), in PL/SQL bodies and trigger
+  functions through the mechanical rewriter and in views, check
+  conditions, defaults, and trigger WHEN clauses through the
+  expression folding. Oracle treats NULL as the empty string where
+  PostgreSQL || yields NULL; concat() ignores NULLs, and NULLIF
+  restores the one case Oracle does return NULL - every part empty.
+  Inner rewrites (SYSDATE, NVL, bind folding) compose inside the
+  operands, and Oracle's CONCAT() function folds the same way.
 - Triggers convert: a simple DML trigger becomes a trigger function
   plus the CREATE TRIGGER statement PostgreSQL wants. :NEW and :OLD
   lose their colons, INSERTING/UPDATING/DELETING become TG_OP tests,

--- a/src/pgrecon/convert/identifiers.py
+++ b/src/pgrecon/convert/identifiers.py
@@ -96,12 +96,31 @@ def ident(name: str) -> str:
     return '"' + name.replace('"', '""') + '"'
 
 
+def _concat_parts(node: Expr) -> list[Expr]:
+    """The operands of a concatenation, flattened across its links."""
+    if isinstance(node, exp.DPipe):
+        return _concat_parts(node.this) + _concat_parts(node.expression)
+    if isinstance(node, exp.Concat):
+        parts: list[Expr] = []
+        for operand in node.expressions:
+            parts.extend(_concat_parts(operand))
+        return parts
+    return [node]
+
+
 def _fold_identifiers(tree: Expr) -> Expr:
     """Lowercase and unquote identifiers; drop schema qualifiers.
 
     DBMS_METADATA quotes every identifier in uppercase; carried as-is
     the view would reference "EMP" while the converted table is emp.
     Single-schema conversion also drops the owner prefix.
+
+    Concatenation chains become NULLIF(concat(...), ''): Oracle ||
+    treats NULL as the empty string where PostgreSQL || yields NULL,
+    concat() ignores NULLs, and NULLIF restores the one case Oracle
+    does return NULL - every part empty, since in Oracle '' IS NULL.
+    The concat call is emitted anonymously because sqlglot renders its
+    own Concat node back to || on the postgres dialect.
     """
     for node in tree.walk():
         if isinstance(node, exp.Identifier):
@@ -109,6 +128,19 @@ def _fold_identifiers(tree: Expr) -> Expr:
             node.set("quoted", not _PLAIN_IDENT.match(node.name.lower()))
         if isinstance(node, exp.Table | exp.Column) and node.args.get("db"):
             node.set("db", None)
+    chains = [
+        node
+        for node in tree.walk()
+        if isinstance(node, exp.DPipe | exp.Concat)
+        and not isinstance(node.parent, exp.DPipe | exp.Concat)
+    ]
+    for chain in chains:
+        chain.replace(
+            exp.Nullif(
+                this=exp.Anonymous(this="concat", expressions=_concat_parts(chain)),
+                expression=exp.Literal.string(""),
+            )
+        )
     return tree
 
 

--- a/src/pgrecon/convert/plsql_rewrite.py
+++ b/src/pgrecon/convert/plsql_rewrite.py
@@ -440,6 +440,29 @@ class _Rewriter(PlSqlParserListener):  # type: ignore[misc]
             else:
                 self._edit_ctx(routine, f"CALL {spelled}")
 
+    def enterConcatenation(self, ctx: Any) -> None:
+        # Oracle || treats NULL as the empty string; PostgreSQL ||
+        # yields NULL when any part is NULL. concat() ignores NULLs,
+        # and NULLIF restores the one case where Oracle does return
+        # NULL: every part empty, because in Oracle '' IS NULL.
+        if len(ctx.BAR()) != 2:
+            return
+        parent = ctx.parentCtx
+        if type(parent).__name__ == "ConcatenationContext" and len(parent.BAR()) == 2:
+            return
+        links: list[Any] = []
+        stack = [ctx]
+        while stack:
+            node = stack.pop()
+            bars = node.BAR()
+            if len(bars) == 2:
+                links.append(bars)
+                stack.extend(node.concatenation())
+        self._edit(ctx.start.start, ctx.start.start - 1, "NULLIF(concat(")
+        for first, second in links:
+            self._edit(first.symbol.start, second.symbol.stop, ",")
+        self._edit(ctx.stop.stop + 1, ctx.stop.stop, "), '')")
+
     def enterException_handler(self, ctx: Any) -> None:
         for name in ctx.exception_name():
             self._condition(name)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from pgrecon.convert import convert_schema, residue_report
+from pgrecon.convert.identifiers import _fold_condition
 from pgrecon.convert.schema import ident
 from pgrecon.convert.typemap import map_type
 from pgrecon.inventory import open_db
@@ -151,6 +152,16 @@ def test_bfile_column_becomes_residue_not_ddl(facts_db: Path) -> None:
 def test_not_null_check_is_not_duplicated(facts_db: Path) -> None:
     result = convert_schema(facts_db)
     assert "emp_id_nn" not in result.sql.lower()
+
+
+def test_condition_concatenation_null_safe() -> None:
+    # The sqlglot lane (checks, defaults, trigger WHEN, views) gets
+    # the same Oracle NULL-as-empty concatenation semantics as the
+    # PL/SQL lane, for both || and Oracle's CONCAT().
+    folded = _fold_condition('"KIND" || "TAG" <> \'xy\'')
+    assert folded == "NULLIF(CONCAT(kind, tag), '') <> 'xy'"
+    folded = _fold_condition('CONCAT("KIND", "TAG") <> \'xy\'')
+    assert folded == "NULLIF(CONCAT(kind, tag), '') <> 'xy'"
 
 
 def test_date_mapping_is_noted(facts_db: Path) -> None:

--- a/tests/test_convert_code.py
+++ b/tests/test_convert_code.py
@@ -164,6 +164,15 @@ BEGIN
   inout_p(v);
 END pcall_p;"""
 
+CONCAT3_P = """PROCEDURE concat3_p(p VARCHAR2) IS
+  v VARCHAR2(100);
+BEGIN
+  v := 'a' || p || 'b';
+  v := 'a' || (p || 'b');
+  EXECUTE IMMEDIATE 'insert into t_fees (kind) values (:k)'
+    USING v || 'x';
+END concat3_p;"""
+
 _UNITS = [
     ("FEE_FOR", "FUNCTION", FEE_FOR),
     ("AUTON_P", "PROCEDURE", AUTON_P),
@@ -185,6 +194,7 @@ _UNITS = [
     ("BINDS_LOOSE_P", "PROCEDURE", BINDS_LOOSE_P),
     ("BINDS_OUT_P", "PROCEDURE", BINDS_OUT_P),
     ("PCALL_P", "PROCEDURE", PCALL_P),
+    ("CONCAT3_P", "PROCEDURE", CONCAT3_P),
 ]
 
 
@@ -318,8 +328,25 @@ def test_refusal_cascades_to_callers(code_db: Path) -> None:
 
 def test_routine_count_matches_emitted(code_db: Path) -> None:
     result = convert_schema(code_db)
-    assert result.routines == 8
-    assert result.sql.count("LANGUAGE plpgsql") == 8
+    assert result.routines == 9
+    assert result.sql.count("LANGUAGE plpgsql") == 9
+
+
+def test_concatenation_carries_oracle_null_semantics(code_db: Path) -> None:
+    # Oracle || treats NULL as '', PostgreSQL || yields NULL; the
+    # chain becomes NULLIF(concat(...), '') with inner rewrites like
+    # SYSDATE and NVL composing inside the operands.
+    result = convert_schema(code_db)
+    sql = result.sql
+    assert "v := NULLIF(concat('a' , p , 'b'), '');" in sql
+    assert "NULLIF(concat('a' , (NULLIF(concat(p , 'b'), ''))), '')" in sql
+    assert (
+        "NULLIF(concat(COALESCE(p_kind, 'it''s flat') ,"
+        " TO_CHAR(CURRENT_TIMESTAMP, 'YYYY')), '')" in sql
+    )
+    assert "NULLIF(concat('fee at ' , CURRENT_TIMESTAMP), '')" in sql
+    assert "values ($1)'" in sql
+    assert "USING NULLIF(concat(v , 'x'), '');" in sql
 
 
 def test_bare_procedure_calls_gain_call(code_db: Path) -> None:

--- a/tests/test_convert_triggers.py
+++ b/tests/test_convert_triggers.py
@@ -65,7 +65,7 @@ AFTER INSERT OR UPDATE OR DELETE ON t_fees
 FOR EACH ROW
 WHEN (new.fee > 0)
 BEGIN
-  DBMS_OUTPUT.PUT_LINE('fee touched');
+  DBMS_OUTPUT.PUT_LINE('fee: ' || :NEW.fee);
 END;"""
 
 _TRIGGERS = [
@@ -203,6 +203,12 @@ def test_new_reference_with_delete_moves_when_into_body(trigger_db: Path) -> Non
     assert "CREATE TRIGGER trg_whendel AFTER insert OR update OR delete" in result.sql
     header = result.sql.split("CREATE TRIGGER trg_whendel", 1)[1].split(";", 1)[0]
     assert "WHEN" not in header
+
+
+def test_trigger_body_concatenation_null_safe(trigger_db: Path) -> None:
+    result = convert_schema(trigger_db)
+    section = result.sql.split("trg_whendel_fn", 2)[1]
+    assert "NULLIF(concat('fee: ' , NEW.fee), '')" in section
 
 
 def test_trigger_count(trigger_db: Path) -> None:


### PR DESCRIPTION
Oracle `||` treats NULL as the empty string; PostgreSQL `||` yields NULL the moment any part is NULL. A converted body could silently print or compare NULL where Oracle produced text - seen live in Round 7 as `<NULL>` trigger notices.

Every `||` chain now becomes `NULLIF(concat(...), '')`:

- `concat()` ignores NULLs, matching Oracle's NULL-as-empty behavior.
- `NULLIF(..., '')` restores the one case Oracle does return NULL: every part empty, because in Oracle `'' IS NULL`. Without it, `WHERE a || b = c || d` returns wrong rows on all-NULL data.
- The rewriter wraps the chain root with pure insertions and turns each `||` into a comma, so inner rewrites (SYSDATE, NVL, $N bind folding) compose inside operands untouched.
- The sqlglot lane gives views, checks, defaults, and trigger WHEN clauses the same treatment, including Oracle's `CONCAT()` function. The concat call is emitted anonymously because sqlglot renders its own Concat node back to `||` on postgres.

Trigger functions and flattened package members inherit the rewrite through `rewrite_unit`. 194 tests.