### PR TITLE
convert: CONNECT BY views become WITH RECURSIVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
 
+## Unreleased
+
+- CONNECT BY views convert to WITH RECURSIVE: one table, one PRIOR
+  equality, projections of plain columns, LEVEL, and
+  SYS_CONNECT_BY_PATH with a literal separator. START WITH filters
+  the base branch, a WHERE applies after the hierarchy as Oracle
+  evaluates it, and a hidden key column carries the parent join so
+  the projection list does not have to. NOCYCLE, ORDER SIBLINGS BY,
+  joins, and PRIOR expressions refuse by name.
+
 ## 0.3.0 - 2026-08-20
 
 - Triggers convert: a simple DML trigger becomes a trigger function

--- a/src/pgrecon/convert/views.py
+++ b/src/pgrecon/convert/views.py
@@ -8,7 +8,7 @@ from sqlglot import Expr, exp
 from sqlglot.errors import ErrorLevel, SqlglotError
 from sqlglot.transforms import eliminate_join_marks
 
-from pgrecon.convert.identifiers import _fold_identifiers
+from pgrecon.convert.identifiers import _fold_identifiers, ident
 from pgrecon.convert.residue import Residue
 from pgrecon.inventory.loader import PARSE_NORMALIZATIONS
 
@@ -56,6 +56,151 @@ def _view_guard(
         if lost:
             return f"references {lost[0]}, a column that was not converted"
     return None
+
+
+def _connect_by_view(tree: Expr, declared: list[str]) -> tuple[str | None, str | None]:
+    """A hierarchical query as WITH RECURSIVE, or a named refusal.
+
+    The provable subset: one table, one PRIOR equality, projections of
+    plain columns, LEVEL, and SYS_CONNECT_BY_PATH over a column with a
+    literal separator. START WITH filters the base branch; a WHERE
+    applies after the hierarchy, which is Oracle's evaluation order. A
+    hidden key column carries the parent side of the join so the
+    projection list does not have to.
+    """
+    select = tree.find(exp.Select)
+    connect = tree.find(exp.Connect)
+    if select is None or connect is None:
+        return None, "the hierarchical query shape did not dissect"
+    if connect.args.get("nocycle"):
+        return None, (
+            "CONNECT BY NOCYCLE breaks cycles at runtime; add a CYCLE"
+            " clause to the recursive query by hand"
+        )
+    if select.args.get("joins"):
+        return None, (
+            "CONNECT BY combined with joins has no mechanical"
+            " translation; rewrite the query by hand"
+        )
+    order = select.args.get("order")
+    if order is not None and "SIBLINGS" in order.sql(dialect="oracle").upper():
+        return None, (
+            "ORDER SIBLINGS BY orders within each parent; order the"
+            " recursive result by hand"
+        )
+    cond = connect.args.get("connect")
+    if not isinstance(cond, exp.EQ):
+        return None, (
+            "only a single PRIOR equality converts mechanically;"
+            " rewrite the CONNECT BY condition by hand"
+        )
+    sides = [cond.this, cond.expression]
+    priors = [s for s in sides if isinstance(s, exp.Prior)]
+    plains = [s for s in sides if isinstance(s, exp.Column)]
+    if len(priors) != 1 or len(plains) != 1:
+        return None, (
+            "only a single PRIOR equality converts mechanically;"
+            " rewrite the CONNECT BY condition by hand"
+        )
+    prior_inner = priors[0].this
+    if not isinstance(prior_inner, exp.Column):
+        return None, (
+            "PRIOR over an expression has no mechanical translation;"
+            " rewrite the condition by hand"
+        )
+    parent_col = ident(prior_inner.name)
+    child_col = ident(plains[0].name)
+    start = connect.args.get("start")
+    if start is not None and (
+        any(True for _ in start.find_all(exp.Prior))
+        or any(c.name.lower() == "level" for c in start.find_all(exp.Column))
+    ):
+        return None, (
+            "START WITH over PRIOR or LEVEL has no mechanical"
+            " translation; rewrite the condition by hand"
+        )
+
+    names: list[str] = []
+    base_items: list[str] = []
+    rec_items: list[str] = []
+    for proj in select.expressions:
+        alias = None
+        inner = proj
+        if isinstance(proj, exp.Alias):
+            alias = proj.alias
+            inner = proj.this
+        if isinstance(inner, exp.Column) and inner.name.lower() == "level":
+            name = alias or "level"
+            base_items.append("1")
+            rec_items.append(f"h.{ident(name)} + 1")
+        elif isinstance(inner, exp.Column):
+            name = alias or inner.name
+            column = ident(inner.name)
+            base_items.append(column)
+            rec_items.append(f"c.{column}")
+        elif (
+            isinstance(inner, exp.Anonymous)
+            and str(inner.this).upper() == "SYS_CONNECT_BY_PATH"
+            and len(inner.expressions) == 2
+            and isinstance(inner.expressions[0], exp.Column)
+            and isinstance(inner.expressions[1], exp.Literal)
+            and inner.expressions[1].is_string
+        ):
+            name = alias or "path"
+            column = ident(inner.expressions[0].name)
+            separator = str(inner.expressions[1].this).replace("'", "''")
+            base_items.append(f"concat('{separator}', {column})")
+            rec_items.append(f"concat(h.{ident(name)}, '{separator}', c.{column})")
+        else:
+            return None, (
+                f"projection {proj.sql(dialect='oracle')} is beyond plain"
+                " columns, LEVEL, and SYS_CONNECT_BY_PATH; rewrite the"
+                " view by hand"
+            )
+        names.append(name)
+    if declared and len(declared) == len(names):
+        names = list(declared)
+    names = [ident(n) for n in names]
+
+    tables = list(select.find_all(exp.Table))
+    if len(tables) != 1:
+        return None, (
+            "CONNECT BY over more than one table has no mechanical"
+            " translation; rewrite the query by hand"
+        )
+    source = ident(tables[0].name)
+
+    key = "pgr_key"
+    while key in names:
+        key = key + "_"
+    base_items.append(parent_col)
+    rec_items.append(f"c.{parent_col}")
+
+    base_where = ""
+    if start is not None:
+        base_where = f"\n  WHERE {start.sql(dialect='postgres')}"
+    where = select.args.get("where")
+    outer_where = ""
+    if where is not None:
+        outer_where = f"\nWHERE {where.this.sql(dialect='postgres')}"
+    outer_order = ""
+    if order is not None:
+        outer_order = f"\n{order.sql(dialect='postgres')}"
+
+    columns = ", ".join(names)
+    statement = (
+        f"WITH RECURSIVE hierarchy ({columns}, {key}) AS (\n"
+        f"  SELECT {', '.join(base_items)}\n"
+        f"  FROM {source}{base_where}\n"
+        f"  UNION ALL\n"
+        f"  SELECT {', '.join(rec_items)}\n"
+        f"  FROM {source} AS c\n"
+        f"  JOIN hierarchy AS h ON c.{child_col} = h.{key}\n"
+        f")\n"
+        f"SELECT {columns}\n"
+        f"FROM hierarchy{outer_where}{outer_order}"
+    )
+    return statement, None
 
 
 def _emit_views(
@@ -131,15 +276,32 @@ def _emit_views(
             # verbatim instead of flagging them; wrong DDL must become
             # residue, never output, so the tree is checked explicitly.
             if tree.find(exp.Connect) is not None:
-                residue.append(
-                    Residue(
-                        r["owner"],
-                        name,
-                        "view",
-                        "needs a manual rewrite: CONNECT BY becomes a"
-                        " WITH RECURSIVE query",
-                    )
+                folded = _fold_identifiers(tree)
+                declared = (
+                    [e.name for e in folded.this.expressions]
+                    if isinstance(folded.this, exp.Schema)
+                    else []
                 )
+                built, why = _connect_by_view(folded, declared)
+                if built is None:
+                    residue.append(
+                        Residue(
+                            r["owner"],
+                            name,
+                            "view",
+                            why or "the hierarchical query did not dissect",
+                        )
+                    )
+                    continue
+                guard = _view_guard(folded, name, emitted, dropped, created_views)
+                if guard is not None:
+                    residue.append(Residue(r["owner"], name, "view", guard))
+                    continue
+                out.append(f"CREATE VIEW {ident(name.lower())} AS\n{built};")
+                out.append("")
+                created_views.add(name.upper())
+                wrote = True
+                count += 1
                 continue
             # Oracle (+) outer joins become ANSI joins; the rule is a
             # no-op on queries without join marks.

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -305,12 +305,52 @@ def test_plain_view_transpiles_with_folded_identifiers(facts_db: Path) -> None:
     assert "FROM emp" in sql
 
 
-def test_connect_by_view_becomes_residue(facts_db: Path) -> None:
+def test_connect_by_view_becomes_with_recursive(facts_db: Path) -> None:
+    # No START WITH: Oracle roots the hierarchy at every row, so the
+    # base branch carries no filter.
     result = convert_schema(facts_db)
-    tree = [r for r in result.residue if r.object_name == "V_TREE"]
-    assert len(tree) == 1
-    assert tree[0].kind == "view"
-    assert "rewrite" in tree[0].reason
+    sql = result.sql
+    assert "CREATE VIEW v_tree AS" in sql
+    assert "WITH RECURSIVE hierarchy (emp_id, pgr_key) AS (" in sql
+    assert "SELECT emp_id, emp_id\n  FROM emp\n  UNION ALL" in sql
+    assert "JOIN hierarchy AS h ON c.dept_id = h.pgr_key" in sql
+    assert not [r for r in result.residue if r.object_name == "V_TREE"]
+
+
+def test_connect_by_full_shape_and_refusals(facts_db: Path) -> None:
+    import sqlite3
+
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO ddl (owner, name, type, ddl, parse_ok, parse_quality) VALUES
+          ('HR', 'V_CHART', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_CHART" ("EMP_ID", "DEPTH", "CHAIN")'
+           || ' AS SELECT emp_id, LEVEL AS depth,'
+           || ' SYS_CONNECT_BY_PATH(ename, ''/'') AS chain FROM emp'
+           || ' START WITH dept_id IS NULL CONNECT BY PRIOR emp_id = dept_id',
+           1, 'full'),
+          ('HR', 'V_NOCYC', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_NOCYC" AS SELECT emp_id FROM emp'
+           || ' CONNECT BY NOCYCLE PRIOR emp_id = dept_id', 1, 'full'),
+          ('HR', 'V_SIBS', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_SIBS" AS SELECT emp_id FROM emp'
+           || ' CONNECT BY PRIOR emp_id = dept_id ORDER SIBLINGS BY emp_id',
+           1, 'full');
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    sql = result.sql
+    assert "CREATE VIEW v_chart AS" in sql
+    assert "WITH RECURSIVE hierarchy (emp_id, depth, chain, pgr_key) AS (" in sql
+    assert "SELECT emp_id, 1, concat('/', ename), emp_id" in sql
+    assert "WHERE dept_id IS NULL" in sql
+    assert "h.depth + 1, concat(h.chain, '/', c.ename), c.emp_id" in sql
+    reasons = {r.object_name: r.reason for r in result.residue if r.kind == "view"}
+    assert "CYCLE clause" in reasons["V_NOCYC"]
+    assert "ORDER SIBLINGS BY" in reasons["V_SIBS"]
 
 
 def test_plus_join_view_becomes_ansi_join(facts_db: Path) -> None:
@@ -318,7 +358,7 @@ def test_plus_join_view_becomes_ansi_join(facts_db: Path) -> None:
     assert "v_oldjoin" in result.sql
     assert "(+)" not in result.sql
     assert "LEFT" in result.sql
-    assert result.views == 2
+    assert result.views == 3
 
 
 @pytest.fixture()


### PR DESCRIPTION
Closes the one genuine free-tier capability gap SCT held in the nine-schema comparison. Mechanical subset: one table, one `PRIOR` equality, projections of plain columns, `LEVEL`, and `SYS_CONNECT_BY_PATH` with a literal separator. `START WITH` filters the base branch; a `WHERE` applies after the hierarchy (Oracle's evaluation order); a hidden `pgr_key` column carries the parent join so the projection list does not have to. `NOCYCLE`, `ORDER SIBLINGS BY`, joins, and `PRIOR` expressions refuse by name.

RECON_TEST's `v_org_chart` converts on the first live run; row-equivalence gauntlet against SCT's WITH RECURSIVE version follows on the lab VM.