### PR TITLE
convert: DECODE keeps Oracle null rules; JSON_TABLE refuses by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
 
 ## Unreleased
 
+- DECODE translates with Oracle's null rules intact: an empty-string
+  argument is a NULL search, result, or default, so it becomes IS
+  NULL or a NULL literal instead of a comparison against '' that
+  could never match. Literal searches keep plain equality; a column
+  search carries the both-NULL match DECODE gives it.
+- Views over JSON_TABLE refuse by name instead of surfacing a parser
+  error: PostgreSQL adds JSON_TABLE in version 17 with different
+  clause syntax, and the residue line now says so.
 - CONNECT BY views convert to WITH RECURSIVE: one table, one PRIOR
   equality, projections of plain columns, LEVEL, and
   SYS_CONNECT_BY_PATH with a literal separator. START WITH filters

--- a/src/pgrecon/convert/identifiers.py
+++ b/src/pgrecon/convert/identifiers.py
@@ -157,6 +157,16 @@ def _fold_identifiers(tree: Expr) -> Expr:
     for node in tree.walk():
         if isinstance(node, exp.Div) and not isinstance(node.this, exp.Cast):
             node.set("this", exp.Cast(this=node.this, to=exp.DataType.build("DECIMAL")))
+    # Oracle folds '' to NULL, so a DECODE argument written as '' is a
+    # NULL search, result, or default; compared as a real empty string
+    # it would never match. The rest of the translation is sqlglot's
+    # CASE, which renders NULL searches as IS NULL and column searches
+    # with a both-NULL match - DECODE's null-equals-null rule.
+    for node in tree.walk():
+        if isinstance(node, exp.DecodeCase):
+            for item in list(node.expressions):
+                if isinstance(item, exp.Literal) and item.is_string and not item.this:
+                    item.replace(exp.Null())
     return tree
 
 

--- a/src/pgrecon/convert/views.py
+++ b/src/pgrecon/convert/views.py
@@ -20,6 +20,8 @@ _PARTITION_SCOPED = re.compile(r"\bPARTITION\s*\(", re.IGNORECASE)
 
 _OBJECT_VIEW = re.compile(r"\bVIEW\s+\"?[^\s(]+\s+OF\s", re.IGNORECASE)
 
+_JSON_TABLE = re.compile(r"\bJSON_TABLE\s*\(", re.IGNORECASE)
+
 
 def _view_guard(
     tree: Expr,
@@ -262,6 +264,18 @@ def _emit_views(
                     "view",
                     "uses a partition-scoped query; PostgreSQL reads the"
                     " child table directly - rewrite by hand",
+                )
+            )
+            continue
+        if _JSON_TABLE.search(text):
+            residue.append(
+                Residue(
+                    r["owner"],
+                    name,
+                    "view",
+                    "uses JSON_TABLE, which PostgreSQL adds in version 17"
+                    " with different clause syntax; rewrite the view by"
+                    " hand",
                 )
             )
             continue

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -353,6 +353,63 @@ def test_connect_by_full_shape_and_refusals(facts_db: Path) -> None:
     assert "ORDER SIBLINGS BY" in reasons["V_SIBS"]
 
 
+def test_decode_views_keep_oracle_null_semantics(facts_db: Path) -> None:
+    import sqlite3
+
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO ddl (owner, name, type, ddl, parse_ok, parse_quality) VALUES
+          ('HR', 'V_DEC', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_DEC" AS SELECT'
+           || ' DECODE(ename, ''a'', 1, ''b'', 2, 0) AS lit_code,'
+           || ' DECODE(ename, '''', ''missing'', ename) AS empty_search,'
+           || ' DECODE(dept_id, emp_id, ''self'', ''other'') AS col_search,'
+           || ' DECODE(ename, ''gone'', '''', ename) AS empty_result'
+           || ' FROM emp', 1, 'full');
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    sql = result.sql
+    # Literal searches keep plain equality: a NULL operand matches no
+    # branch and falls to the default, in Oracle and PostgreSQL alike.
+    assert "CASE WHEN ename = 'a' THEN 1 WHEN ename = 'b' THEN 2 ELSE 0 END" in sql
+    # Oracle folds '' to NULL, as a search and as a result.
+    assert "CASE WHEN ename IS NULL THEN 'missing' ELSE ename END" in sql
+    assert "CASE WHEN ename = 'gone' THEN NULL ELSE ename END" in sql
+    # A column search can be NULL at runtime, and DECODE matches two
+    # NULLs; plain equality would fall through to the default.
+    assert "WHEN dept_id = emp_id OR (" in sql
+    assert "dept_id IS NULL AND emp_id IS NULL" in sql
+    assert "= ''" not in sql
+    assert not [r for r in result.residue if r.object_name == "V_DEC"]
+
+
+def test_json_table_view_refuses_by_name(facts_db: Path) -> None:
+    import sqlite3
+
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO ddl (owner, name, type, ddl, parse_ok, parse_quality) VALUES
+          ('HR', 'V_JSON', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_JSON" AS SELECT jt.item'
+           || ' FROM emp, JSON_TABLE(ename, ''$.items[*]'''
+           || ' COLUMNS (item VARCHAR2(100) PATH ''$.name'')) jt',
+           1, 'full');
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    reasons = {r.object_name: r.reason for r in result.residue if r.kind == "view"}
+    assert "JSON_TABLE" in reasons["V_JSON"]
+    assert "version 17" in reasons["V_JSON"]
+    assert "V_JSON" not in result.sql
+
+
 def test_plus_join_view_becomes_ansi_join(facts_db: Path) -> None:
     result = convert_schema(facts_db)
     assert "v_oldjoin" in result.sql


### PR DESCRIPTION
Two expression-lane items.

DECODE: Oracle folds '' to NULL, so a DECODE argument written as '' is a NULL search, result, or default. Compared as a real empty string it could never match. The identifier fold now replaces empty-string literals among DECODE arguments with NULL, and sqlglot's CASE translation does the rest: IS NULL for NULL searches, plain equality for literal searches (a NULL operand falls to the default in both engines), and a both-NULL match for column searches - DECODE's null-equals-null rule, pinned by tests so a sqlglot upgrade cannot silently regress it.

JSON_TABLE: views over JSON_TABLE refused before with the parser's error text (CO's PRODUCT_REVIEWS got 'Expecting ). Line 4, Col: 32'). They now refuse by name: PostgreSQL adds JSON_TABLE in version 17 with different clause syntax, and the residue line says so.

No output changes across the nine comparison schemas - none uses DECODE in a view, check, or index expression - so the live gauntlet results stand; CO's residue wording is the only delta.