### PR TITLE
convert: name the loss when a materialized view converts as a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
 
 ## Unreleased
 
+- Materialized views stop converting silently: DBMS_METADATA hands
+  them over as container tables, so the table still converts and a
+  residue line now names the loss - the defining query is not in the
+  inventory, refresh must be scheduled by hand, and query rewrite has
+  no PostgreSQL counterpart.
 - DECODE translates with Oracle's null rules intact: an empty-string
   argument is a NULL search, result, or default, so it becomes IS
   NULL or a NULL literal instead of a comparison against '' that

--- a/src/pgrecon/convert/tables.py
+++ b/src/pgrecon/convert/tables.py
@@ -61,6 +61,16 @@ def emit_tables(
         if ((fk["rtab"] or "").upper(), (fk["rcol"] or "").upper()) in identity_cols
     }
 
+    # DBMS_METADATA hands a materialized view over as its container
+    # table, so the defining query never reaches the inventory; the
+    # table converts, and the residue names what was lost.
+    mviews = {
+        ((r["owner"] or "").upper(), (r["mview_name"] or "").upper()): r
+        for r in conn.execute(
+            "SELECT owner, mview_name, rewrite_enabled, refresh_method FROM mviews"
+        )
+    }
+
     tables = conn.execute(
         "SELECT owner, table_name, temporary FROM tables ORDER BY owner, table_name"
     ).fetchall()
@@ -203,6 +213,21 @@ def emit_tables(
                     " per-session semantics need pgtt or a redesign",
                 )
             )
+        mv = mviews.get(((owner or "").upper(), (table or "").upper()))
+        if mv is not None:
+            refresh = (mv["refresh_method"] or "unknown").upper()
+            reason = (
+                "materialized view emitted as a plain table; the defining"
+                " query is not in the inventory - recreate it as CREATE"
+                " MATERIALIZED VIEW and schedule REFRESH by hand"
+                f" (Oracle refresh method: {refresh})"
+            )
+            if (mv["rewrite_enabled"] or "N") == "Y":
+                reason += (
+                    "; query rewrite does not exist in PostgreSQL - point"
+                    " queries at the materialized view directly"
+                )
+            residue.append(Residue(owner, table, "materialized view", reason))
         out.append(f"CREATE TABLE {ident(table)} (")
         out.append(",\n".join(lines))
         out.append(f"){meta.clause if meta else ''};")

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -410,6 +410,33 @@ def test_json_table_view_refuses_by_name(facts_db: Path) -> None:
     assert "V_JSON" not in result.sql
 
 
+def test_materialized_view_container_notes_the_loss(facts_db: Path) -> None:
+    import sqlite3
+
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO tables (owner, table_name, temporary) VALUES
+          ('HR', 'MV_DEPT_SUM', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'MV_DEPT_SUM', 'DNAME', 1, 'VARCHAR2', 14, NULL, NULL, 'N'),
+          ('HR', 'MV_DEPT_SUM', 'TOTAL', 2, 'NUMBER', 22, NULL, NULL, 'Y');
+        INSERT INTO mviews (owner, mview_name, rewrite_enabled, refresh_method)
+          VALUES ('HR', 'MV_DEPT_SUM', 'Y', 'COMPLETE');
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    assert "CREATE TABLE mv_dept_sum (" in result.sql
+    mv = [r for r in result.residue if r.kind == "materialized view"]
+    assert len(mv) == 1 and mv[0].object_name == "MV_DEPT_SUM"
+    assert "refresh method: COMPLETE" in mv[0].reason
+    assert "query rewrite does not exist" in mv[0].reason
+
+
 def test_plus_join_view_becomes_ansi_join(facts_db: Path) -> None:
     result = convert_schema(facts_db)
     assert "v_oldjoin" in result.sql


### PR DESCRIPTION
DBMS_METADATA extracts a materialized view as its container table, so the defining query never reaches the inventory. The converter emitted the plain table and silently dropped the materialized-ness - the one gap the Round 11 coverage count exposed (a denominator row with no residue line).

The table still converts; a residue line now names the loss, quotes the Oracle refresh method, and when query rewrite was enabled says plainly that PostgreSQL has no counterpart - queries must target the materialized view directly.

Real conversion (CREATE MATERIALIZED VIEW from the defining query) needs DBA_MVIEWS.QUERY in the extraction, which is LONG-typed and rides the next extraction-script session alongside partition HIGH_VALUE and license exposure.

Residue-only change: emitted SQL is byte-identical across the nine schemas, so the live gauntlet results stand.