### PR TITLE
extract: license posture, mview queries, and full partition bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
 
+## Unreleased
+
+- The extraction scripts capture license posture and the two facts
+  that were LONG-locked. license.csv carries the edition banner and
+  cpu counts; feature_usage.csv carries DBA_FEATURE_USAGE_STATISTICS
+  (both need SELECT_CATALOG_ROLE and degrade to empty files without
+  it). Materialized views now arrive with their defining query, and
+  partitions with their full HIGH_VALUE - complete in the modern
+  script via SET LONG, and in the legacy script through the same
+  PL/SQL streaming the view DDL already used, where HIGH_VALUE keeps
+  the 180-byte cut with its truncated flag. The inventory gains
+  license_facts and feature_usage tables and a query column on
+  mviews.
+
 ## 0.4.0 - 2026-08-21
 
 - CONNECT BY views convert to WITH RECURSIVE: one table, one PRIOR

--- a/src/pgrecon/extract/pgrecon_extract.sql
+++ b/src/pgrecon/extract/pgrecon_extract.sql
@@ -20,8 +20,10 @@
 --      assessment.
 --
 -- Review notice: this script is intentionally plain so that a DBA can
--- audit every statement before running it. Every query below selects
--- from ALL_* dictionary views or DUAL only.
+-- audit every statement before running it. Every query below reads
+-- dictionary and performance views only (ALL_*, and for plan
+-- management and the license facts, DBA_* and V$ views covered by
+-- SELECT_CATALOG_ROLE). No statement reads table data.
 
 WHENEVER OSERROR CONTINUE
 WHENEVER SQLERROR CONTINUE
@@ -233,6 +235,21 @@ SELECT owner, name, column_name, column_position
  ORDER BY name, column_position;
 SPOOL OFF
 
+-- HIGH_VALUE is a LONG column; SET LONG above lets it spool complete.
+-- The boundary expression of each partition is what a converter needs
+-- to emit exact PostgreSQL partition bounds.
+SPOOL part_partitions.csv
+SELECT table_owner AS owner,
+       table_name,
+       partition_name,
+       partition_position AS position,
+       0 AS truncated,
+       high_value
+  FROM all_tab_partitions
+ WHERE table_owner = UPPER('&schema')
+ ORDER BY table_name, partition_position;
+SPOOL OFF
+
 -- Sequence facts spool as text: Oracle sequence bounds go to 1e28,
 -- far past any integer type on the loading side.
 SPOOL sequences.csv
@@ -290,9 +307,12 @@ SELECT owner, index_name, table_name, locality
 SPOOL OFF
 
 -- Query-rewrite and refresh settings drive how each materialized
--- view's consumers must change.
+-- view's consumers must change. QUERY is a LONG column; SET LONG
+-- above lets the defining query spool complete, which is what turns
+-- the container table back into a real materialized view on the
+-- PostgreSQL side.
 SPOOL mviews.csv
-SELECT owner, mview_name, rewrite_enabled, refresh_method
+SELECT owner, mview_name, rewrite_enabled, refresh_method, query
   FROM all_mviews
  WHERE owner = UPPER('&schema')
  ORDER BY mview_name;
@@ -309,6 +329,38 @@ SELECT 'OUTLINE', name, enabled
   FROM dba_outlines
  WHERE owner = UPPER('&schema')
  ORDER BY 1, 2;
+SPOOL OFF
+
+-- License posture facts, database-wide: the edition banner and cpu
+-- counts. Facts only - no interpretation happens here, and nothing
+-- below reads table data. Requires SELECT_CATALOG_ROLE; without it
+-- these two files come back empty and the assessment proceeds
+-- without a license section.
+SPOOL license.csv
+SELECT 'banner' AS key, banner AS value
+  FROM v$version
+ WHERE ROWNUM = 1
+UNION ALL
+SELECT 'cpu_count', value FROM v$parameter WHERE name = 'cpu_count'
+UNION ALL
+SELECT 'num_cpu_cores', TO_CHAR(value)
+  FROM v$osstat WHERE stat_name = 'NUM_CPU_CORES'
+UNION ALL
+SELECT 'num_cpus', TO_CHAR(value)
+  FROM v$osstat WHERE stat_name = 'NUM_CPUS';
+SPOOL OFF
+
+-- What the database reports it has actually used, feature by feature.
+-- Separately licensed options showing usage here are the raw material
+-- of a license-exposure review.
+SPOOL feature_usage.csv
+SELECT name,
+       version,
+       detected_usages,
+       currently_used,
+       TO_CHAR(last_usage_date, 'YYYY-MM-DD') AS last_usage
+  FROM dba_feature_usage_statistics
+ ORDER BY name, version;
 SPOOL OFF
 
 -- Feature probes: one row per feature with a count. Each of these

--- a/src/pgrecon/extract/pgrecon_extract_legacy.sql
+++ b/src/pgrecon/extract/pgrecon_extract_legacy.sql
@@ -27,8 +27,11 @@
 --   3. sqlplus readonly_user@service @pgrecon_extract_legacy.sql SCHEMA_NAME
 --   4. Send the resulting folder of .csv and .sql files back.
 --
--- Review notice: every statement below reads ALL_* dictionary views
--- or DUAL only. Nothing is written to the database.
+-- Review notice: every statement below reads dictionary and
+-- performance views only (ALL_*, and for db links, outlines, and the
+-- license facts, DBA_* and V$ views covered by SELECT_CATALOG_ROLE).
+-- Nothing is written to the database, and no statement reads table
+-- data.
 
 WHENEVER OSERROR CONTINUE
 WHENEVER SQLERROR CONTINUE
@@ -250,13 +253,86 @@ SELECT '"' || owner || '","' || REPLACE(index_name, '"', '""') || '","'
  ORDER BY index_name;
 SPOOL OFF
 
+SET SERVEROUTPUT ON SIZE 1000000
+
+-- HIGH_VALUE is a LONG column, unreadable to concatenation; read it
+-- in PL/SQL and cut at 180 bytes with a truncated flag, like the
+-- check conditions below. The modern script carries the full value.
+SPOOL part_partitions.csv
+DECLARE
+    l_hv VARCHAR2(4000);
+BEGIN
+    DBMS_OUTPUT.PUT_LINE('"OWNER","TABLE_NAME","PARTITION_NAME",'
+        || '"POSITION","HIGH_VALUE","TRUNCATED"');
+    FOR p IN (SELECT table_owner, table_name, partition_name,
+                     partition_position, high_value
+                FROM all_tab_partitions
+               WHERE table_owner = UPPER('&schema')
+               ORDER BY table_name, partition_position) LOOP
+        l_hv := SUBSTRB(p.high_value, 1, 180);
+        l_hv := REPLACE(REPLACE(REPLACE(l_hv, '"', '""'),
+                        CHR(13), ' '), CHR(10), ' ');
+        DBMS_OUTPUT.PUT_LINE('"' || p.table_owner || '","' || p.table_name
+            || '","' || p.partition_name || '",' || p.partition_position
+            || ',"' || l_hv || '",'
+            || CASE WHEN LENGTHB(l_hv) >= 180 THEN 1 ELSE 0 END);
+    END LOOP;
+END;
+/
+SPOOL OFF
+
+-- The defining QUERY is also a LONG; stream it inside the quoted CSV
+-- field with the same 240-byte line wrap the view DDL uses. A query
+-- over 32000 characters leaves the field empty rather than partial.
 SPOOL mviews.csv
-SELECT '"OWNER","MVIEW_NAME","REWRITE_ENABLED","REFRESH_METHOD"' FROM dual;
-SELECT '"' || owner || '","' || REPLACE(mview_name, '"', '""') || '","'
-       || rewrite_enabled || '","' || NVL(refresh_method, '') || '"'
-  FROM all_mviews
- WHERE owner = UPPER('&schema')
- ORDER BY mview_name;
+DECLARE
+    l_text VARCHAR2(32767);
+    l_line VARCHAR2(32767);
+    l_pos  PLS_INTEGER;
+BEGIN
+    DBMS_OUTPUT.PUT_LINE('"OWNER","MVIEW_NAME","REWRITE_ENABLED",'
+        || '"REFRESH_METHOD","QUERY"');
+    FOR m IN (SELECT owner, mview_name, rewrite_enabled,
+                     refresh_method, query, query_len
+                FROM all_mviews
+               WHERE owner = UPPER('&schema')
+               ORDER BY mview_name) LOOP
+        -- The row's fixed fields end the line with the query field's
+        -- opening quote; the query streams on the following lines and
+        -- the closing quote ends the last one. The leading newline
+        -- inside the quoted field is harmless whitespace to a parser.
+        DBMS_OUTPUT.PUT_LINE('"' || m.owner || '","'
+            || REPLACE(m.mview_name, '"', '""') || '","'
+            || m.rewrite_enabled || '","'
+            || NVL(m.refresh_method, '') || '","');
+        IF NVL(m.query_len, 0) > 32000 OR m.query IS NULL THEN
+            DBMS_OUTPUT.PUT_LINE('"');
+        ELSE
+            l_text := m.query;
+            WHILE l_text IS NOT NULL LOOP
+                l_pos := INSTR(l_text, CHR(10));
+                IF l_pos = 0 THEN
+                    l_line := l_text;
+                    l_text := NULL;
+                ELSE
+                    l_line := SUBSTR(l_text, 1, l_pos - 1);
+                    l_text := SUBSTR(l_text, l_pos + 1);
+                END IF;
+                l_line := REPLACE(REPLACE(l_line, CHR(13), ''), '"', '""');
+                WHILE LENGTHB(l_line) > 240 LOOP
+                    DBMS_OUTPUT.PUT_LINE(SUBSTRB(l_line, 1, 240));
+                    l_line := SUBSTRB(l_line, 241);
+                END LOOP;
+                IF l_text IS NULL THEN
+                    DBMS_OUTPUT.PUT_LINE(NVL(l_line, ' ') || '"');
+                ELSE
+                    DBMS_OUTPUT.PUT_LINE(NVL(l_line, ' '));
+                END IF;
+            END LOOP;
+        END IF;
+    END LOOP;
+END;
+/
 SPOOL OFF
 
 -- No DBA_SQL_PLAN_BASELINES before 11.1; stored outlines are the
@@ -310,6 +386,68 @@ SELECT '"iot_tables","index organized",' || COUNT(*)
 SELECT '"temporary_tables","global temporary",' || COUNT(*)
   FROM all_tables
  WHERE owner = UPPER('&schema') AND temporary = 'Y';
+SPOOL OFF
+
+-- License posture facts. Dynamic SQL with a swallow-and-continue
+-- guard per fact: V$OSSTAT arrives in 10.1, so a 9.2 server spools
+-- the facts it has and an empty line for the rest, never an error.
+SPOOL license.csv
+DECLARE
+    l_value VARCHAR2(4000);
+    PROCEDURE emit(p_key VARCHAR2, p_sql VARCHAR2) IS
+    BEGIN
+        EXECUTE IMMEDIATE p_sql INTO l_value;
+        DBMS_OUTPUT.PUT_LINE('"' || p_key || '","'
+            || REPLACE(l_value, '"', '""') || '"');
+    EXCEPTION
+        WHEN OTHERS THEN NULL;
+    END;
+BEGIN
+    DBMS_OUTPUT.PUT_LINE('"KEY","VALUE"');
+    emit('banner',
+         'SELECT banner FROM v$version WHERE ROWNUM = 1');
+    emit('cpu_count',
+         'SELECT value FROM v$parameter WHERE name = ''cpu_count''');
+    emit('num_cpu_cores',
+         'SELECT TO_CHAR(value) FROM v$osstat'
+         || ' WHERE stat_name = ''NUM_CPU_CORES''');
+    emit('num_cpus',
+         'SELECT TO_CHAR(value) FROM v$osstat'
+         || ' WHERE stat_name = ''NUM_CPUS''');
+END;
+/
+SPOOL OFF
+
+-- Feature usage arrives with DBA_FEATURE_USAGE_STATISTICS in 10.1; a
+-- 9.2 server leaves only the header row behind.
+SPOOL feature_usage.csv
+DECLARE
+    TYPE t_cur IS REF CURSOR;
+    l_cur     t_cur;
+    l_name    VARCHAR2(200);
+    l_version VARCHAR2(80);
+    l_det     NUMBER;
+    l_used    VARCHAR2(10);
+    l_last    VARCHAR2(20);
+BEGIN
+    DBMS_OUTPUT.PUT_LINE('"NAME","VERSION","DETECTED_USAGES",'
+        || '"CURRENTLY_USED","LAST_USAGE"');
+    OPEN l_cur FOR
+        'SELECT name, version, detected_usages, currently_used,'
+        || ' TO_CHAR(last_usage_date, ''YYYY-MM-DD'')'
+        || ' FROM dba_feature_usage_statistics ORDER BY name, version';
+    LOOP
+        FETCH l_cur INTO l_name, l_version, l_det, l_used, l_last;
+        EXIT WHEN l_cur%NOTFOUND;
+        DBMS_OUTPUT.PUT_LINE('"' || REPLACE(l_name, '"', '""') || '","'
+            || l_version || '",' || NVL(TO_CHAR(l_det), '') || ',"'
+            || NVL(l_used, '') || '","' || NVL(l_last, '') || '"');
+    END LOOP;
+    CLOSE l_cur;
+EXCEPTION
+    WHEN OTHERS THEN NULL;
+END;
+/
 SPOOL OFF
 
 -- ---------------------------------------------------------------

--- a/src/pgrecon/inventory/loader.py
+++ b/src/pgrecon/inventory/loader.py
@@ -277,6 +277,24 @@ CSV_TABLES: dict[str, tuple[str, dict[str, str]]] = {
             "MVIEW_NAME": "mview_name",
             "REWRITE_ENABLED": "rewrite_enabled",
             "REFRESH_METHOD": "refresh_method",
+            "QUERY": "query",
+        },
+    ),
+    "license.csv": (
+        "license_facts",
+        {
+            "KEY": "key",
+            "VALUE": "value",
+        },
+    ),
+    "feature_usage.csv": (
+        "feature_usage",
+        {
+            "NAME": "name",
+            "VERSION": "version",
+            "DETECTED_USAGES": "detected_usages",
+            "CURRENTLY_USED": "currently_used",
+            "LAST_USAGE": "last_usage",
         },
     ),
     "plan_management.csv": (
@@ -296,6 +314,7 @@ INT_COLUMNS = {
     "count",
     "partition_count",
     "truncated",
+    "detected_usages",
 }
 
 DDL_MARKER = re.compile(r"^-- PGRECON_OBJECT (\S+) ([^\s.]+)\.(\S+)\s*$", re.MULTILINE)

--- a/src/pgrecon/inventory/schema.sql
+++ b/src/pgrecon/inventory/schema.sql
@@ -289,6 +289,7 @@ CREATE TABLE mviews (
     mview_name      TEXT NOT NULL,
     rewrite_enabled TEXT,
     refresh_method  TEXT,
+    query           TEXT,
     PRIMARY KEY (owner, mview_name)
 );
 
@@ -296,4 +297,25 @@ CREATE TABLE plan_management (
     kind    TEXT NOT NULL,
     name    TEXT NOT NULL,
     enabled TEXT
+);
+
+-- Database-wide license posture: edition banner, cpu counts. Facts
+-- only; any interpretation of what they cost belongs to a human with
+-- the client's contract in hand.
+CREATE TABLE license_facts (
+    key   TEXT NOT NULL,
+    value TEXT,
+    PRIMARY KEY (key)
+);
+
+-- DBA_FEATURE_USAGE_STATISTICS, database-wide by nature. Readable
+-- with SELECT_CATALOG_ROLE; accounts without it produce an empty
+-- table, never a failed load.
+CREATE TABLE feature_usage (
+    name            TEXT NOT NULL,
+    version         TEXT,
+    detected_usages INTEGER,
+    currently_used  TEXT,
+    last_usage      TEXT,
+    PRIMARY KEY (name, version)
 );

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -314,3 +314,60 @@ def test_wrapped_unit_is_marked_not_parsed(tmp_path: Path) -> None:
     # The base64 payload must produce no token-grep findings either.
     features = conn.execute("SELECT COUNT(*) FROM plsql_features").fetchone()[0]
     assert features == 0
+
+
+def test_license_mview_and_partition_facts_load(tmp_path: Path) -> None:
+    dump = tmp_path / "dump"
+    dump.mkdir()
+    (dump / "license.csv").write_text(
+        '\n"KEY","VALUE"\n'
+        '"banner","Oracle Database 21c Express Edition Release 21.0.0.0.0"\n'
+        '"cpu_count","8"\n',
+        encoding="utf-8",
+    )
+    (dump / "feature_usage.csv").write_text(
+        '\n"NAME","VERSION","DETECTED_USAGES","CURRENTLY_USED","LAST_USAGE"\n'
+        '"Partitioning (user)","21.0.0.0.0",4,"TRUE","2026-08-01"\n',
+        encoding="utf-8",
+    )
+    # The legacy script opens the QUERY field on its own line, so the
+    # value begins with a newline; the loader must keep it verbatim.
+    (dump / "mviews.csv").write_text(
+        '\n"OWNER","MVIEW_NAME","REWRITE_ENABLED","REFRESH_METHOD","QUERY"\n'
+        '"HR","MV_SUM","Y","COMPLETE","\n'
+        "SELECT dept, SUM(sal) AS total\n"
+        "FROM emp\n"
+        'GROUP BY dept"\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+    (dump / "part_partitions.csv").write_text(
+        '\n"OWNER","TABLE_NAME","PARTITION_NAME","POSITION","TRUNCATED",'
+        '"HIGH_VALUE"\n'
+        '"HR","SALES","P2021",1,0,"TO_DATE(\'\' 2021-01-01\'\','
+        " ''YYYY-MM-DD'')\"\n".replace("''", "'"),
+        encoding="utf-8",
+    )
+    db = tmp_path / "inv.db"
+    load_dump(dump, db)
+    conn = sqlite3.connect(db)
+    assert (
+        conn.execute("SELECT value FROM license_facts WHERE key = 'banner'")
+        .fetchone()[0]
+        .startswith("Oracle Database 21c Express")
+    )
+    usage = conn.execute(
+        "SELECT detected_usages, currently_used FROM feature_usage"
+        " WHERE name = 'Partitioning (user)'"
+    ).fetchone()
+    assert usage == (4, "TRUE")
+    query = conn.execute(
+        "SELECT query FROM mviews WHERE mview_name = 'MV_SUM'"
+    ).fetchone()[0]
+    assert query.startswith("\nSELECT dept")
+    assert "GROUP BY dept" in query
+    high = conn.execute(
+        "SELECT high_value, truncated FROM part_partitions"
+        " WHERE partition_name = 'P2021'"
+    ).fetchone()
+    assert high == ("TO_DATE(' 2021-01-01', 'YYYY-MM-DD')", 0)


### PR DESCRIPTION
The extraction scripts gain the facts three roadmap items were waiting on: license.csv (edition banner, cpu counts) and feature_usage.csv (DBA_FEATURE_USAGE_STATISTICS) for the license-exposure work, the materialized-view defining QUERY, and complete partition HIGH_VALUE. Both license spools need SELECT_CATALOG_ROLE and degrade to empty files without it.

Modern tier reads the LONG columns whole via the SET LONG already in force. Legacy tier streams the query through the established PL/SQL line-wrap (field opens on its own line for the pre-10.2 output limit) and keeps the 180-byte cut plus truncated flag for HIGH_VALUE; on 9.2, guarded dynamic SQL leaves header-only files.

Inventory: new license_facts and feature_usage tables, query column on mviews. part_partitions.csv finally has a producer for the loader mapping that always expected it. Live verification against both lab Oracle versions follows on the VM before this feeds the report.