### PR TITLE
dev: one-click Codespaces environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "pgrecon",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
+    "postCreateCommand": "pip install -e .",
+    "customizations": {
+        "codespaces": {
+            "openFiles": ["README.md"]
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/Muzzammil242/pgrecon/actions/workflows/ci.yml/badge.svg)](https://github.com/Muzzammil242/pgrecon/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/pgrecon.svg)](https://pypi.org/project/pgrecon/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Muzzammil242/pgrecon?quickstart=1)
 
 Migration reconnaissance for PostgreSQL. pgrecon inventories an Oracle
 database from an offline dump and runs a deterministic rule engine over

--- a/README.md
+++ b/README.md
@@ -116,17 +116,17 @@ variant for you.
 
 ## What it checks
 
-64 rules at present, each shipping with fixture tests:
+74 rules at present, each shipping with fixture tests:
 
 | Category        | Rules | Among them |
 | --------------- | ----- | ---------- |
 | Data types      | 7     | LONG, XMLTYPE, ROWID and BFILE, TIMESTAMP WITH LOCAL TIME ZONE |
-| Storage         | 9     | interval partitioning, global temporary tables, IOTs, bitmap and function-based indexes |
-| PL/SQL code     | 17    | autonomous transactions, dynamic SQL, FORALL, collection types, the empty-string NULL trap |
-| SQL constructs  | 6     | CONNECT BY, (+) outer joins, ROWNUM, MERGE, DECODE null handling |
+| Storage         | 12    | interval partitioning, global temporary tables, IOTs, read-only tables, bitmap and function-based indexes |
+| PL/SQL code     | 18    | autonomous transactions, dynamic SQL, FORALL, collection types, the empty-string NULL trap |
+| SQL constructs  | 12    | CONNECT BY, (+) outer joins, ROWNUM, MERGE, the MODEL clause, PIVOT, flashback queries |
 | Packages        | 2     | package-level state, initialization blocks |
 | System packages | 5     | UTL_FILE, UTL_HTTP/SMTP/TCP, DBMS_SQL, DBMS_LOB, DBMS_OUTPUT |
-| Schema objects  | 12    | database links, scheduler jobs, materialized views, queues, evolved types, unparseable DDL |
+| Schema objects  | 13    | database links, scheduler jobs, materialized view logs, queues, evolved types, unparseable DDL |
 | Performance     | 5     | optimizer hints, global indexes on partitioned tables, plan baselines, query-rewrite MVs |
 
 Stored PL/SQL is parsed with a full grammar, and code findings come


### PR DESCRIPTION
A devcontainer (python:3.12 image, editable install of the tree) plus the Codespaces badge in the README, so a visitor can try the CLI against the bundled dump without installing anything.

HOLD: main is frozen until the next announcement beat by owner decision. Merge on the owner's word; no release or claim changes ride on this.