### PR TITLE
rules: add spatial, session context, and remote call rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
 - Every rule has a fixture test; fifteen that were exercised nowhere
   gained minimal inventories. The bundled sample's headline numbers
   are asserted so they cannot drift between releases.
+- Three rules take the catalog to 79: spatial columns (SDO_GEOMETRY
+  and the Oracle Spatial family, mapped toward PostGIS), session
+  context reads (SYS_CONTEXT and USERENV, detected as calls at the
+  token level so a column named sys_context stays silent), and
+  remote calls over a database link (a callee with @link, which
+  postgres_fdw cannot serve).
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/README.md
+++ b/README.md
@@ -115,18 +115,18 @@ variant for you.
 
 ## What it checks
 
-76 rules at present, each shipping with fixture tests:
+79 rules at present, each shipping with fixture tests:
 
 | Category        | Rules | Among them |
 | --------------- | ----- | ---------- |
 | Environment     | 2     | character-set encoding decision, object grants to migrate |
-| Data types      | 7     | LONG, XMLTYPE, ROWID and BFILE, TIMESTAMP WITH LOCAL TIME ZONE |
+| Data types      | 8     | LONG, XMLTYPE, ROWID and BFILE, SDO_GEOMETRY, TIMESTAMP WITH LOCAL TIME ZONE |
 | Storage         | 12    | interval partitioning, global temporary tables, IOTs, read-only tables, bitmap and function-based indexes |
 | PL/SQL code     | 18    | autonomous transactions, dynamic SQL, FORALL, collection types, the empty-string NULL trap |
-| SQL constructs  | 12    | CONNECT BY, (+) outer joins, ROWNUM, MERGE, the MODEL clause, PIVOT, flashback queries |
+| SQL constructs  | 13    | CONNECT BY, (+) outer joins, ROWNUM, MERGE, SYS_CONTEXT, the MODEL clause, PIVOT, flashback queries |
 | Packages        | 2     | package-level state, initialization blocks |
 | System packages | 5     | UTL_FILE, UTL_HTTP/SMTP/TCP, DBMS_SQL, DBMS_LOB, DBMS_OUTPUT |
-| Schema objects  | 13    | database links, scheduler jobs, materialized view logs, queues, evolved types, unparseable DDL |
+| Schema objects  | 14    | database links and remote calls over them, scheduler jobs, materialized view logs, queues, evolved types, unparseable DDL |
 | Performance     | 5     | optimizer hints, global indexes on partitioned tables, plan baselines, query-rewrite MVs |
 
 Stored PL/SQL is parsed with a full grammar, and code findings come

--- a/src/pgrecon/plsql/walk.py
+++ b/src/pgrecon/plsql/walk.py
@@ -167,6 +167,13 @@ def _scan_tokens(stream: Any) -> list[Feature]:
             # predefined type name; Ref_cursor_type_def catches the
             # TYPE ... IS REF CURSOR declarations.
             features.append(Feature("ref_cursor", token.line, None))
+        elif token.type in (PlSqlLexer.SYS_CONTEXT, PlSqlLexer.USERENV):
+            # Session-context reads. The lexer keywords both names but
+            # Oracle lets them serve as identifiers, so the call
+            # parenthesis is what separates the function from a
+            # variable or column that happens to share the name.
+            if nxt is not None and nxt.type == PlSqlLexer.LEFT_PAREN:
+                features.append(Feature("sys_context", token.line, token.text.upper()))
         elif token.type == PlSqlLexer.CHAR_STRING and token.text == "''":
             # A standalone empty-string literal, which Oracle treats as
             # NULL and PostgreSQL does not. An escaped quote inside a

--- a/src/pgrecon/rules/columns.py
+++ b/src/pgrecon/rules/columns.py
@@ -130,4 +130,22 @@ RULES = [
             " data_type FROM columns WHERE data_type = 'BFILE'"
         ),
     ),
+    Rule(
+        id="R-TYPE-08",
+        title="Spatial column",
+        category="data types",
+        severity=Severity.HIGH,
+        effort=4.0,
+        remedy=(
+            "SDO_GEOMETRY and the rest of Oracle Spatial map to PostGIS"
+            " geometry and geography types, but the operator vocabulary,"
+            " spatial indexes, and coordinate-system handling all change;"
+            " every spatial query and index is a port, not a translation."
+        ),
+        extension="postgis",
+        detector=sql_detector(
+            "SELECT owner, table_name || '.' || column_name, 'COLUMN',"
+            " data_type FROM columns WHERE data_type LIKE 'SDO_%'"
+        ),
+    ),
 ]

--- a/src/pgrecon/rules/objects.py
+++ b/src/pgrecon/rules/objects.py
@@ -232,4 +232,23 @@ RULES = [
             " WHERE parse_quality = 'fallback'"
         ),
     ),
+    Rule(
+        id="R-OBJ-11",
+        title="Remote call over a database link",
+        category="objects",
+        severity=Severity.HIGH,
+        effort=3.0,
+        remedy=(
+            "A call through @link runs code on another database, which"
+            " postgres_fdw cannot do - it reaches remote tables, not"
+            " remote procedures. Move the logic to the caller's side, to"
+            " the application, or to a queue between the databases."
+        ),
+        extension="postgres_fdw",
+        detector=sql_detector(
+            "SELECT owner, name, type,"
+            " callee || ' (line ' || line || ')' FROM plsql_calls"
+            " WHERE callee LIKE '%@%'"
+        ),
+    ),
 ]

--- a/src/pgrecon/rules/sqlconstructs.py
+++ b/src/pgrecon/rules/sqlconstructs.py
@@ -269,4 +269,31 @@ RULES = [
             )
         ),
     ),
+    Rule(
+        id="R-SRC-28",
+        title="Session context read",
+        category="sql",
+        severity=Severity.MEDIUM,
+        effort=1.0,
+        remedy=(
+            "SYS_CONTEXT and USERENV read Oracle's session context."
+            " current_user, inet_client_addr(), and current_setting()"
+            " over custom parameters cover the common attributes;"
+            " SESSIONID, CLIENT_IDENTIFIER, and application contexts set"
+            " by DBMS_SESSION need each attribute mapped by hand."
+        ),
+        detector=sql_detector(
+            "SELECT owner, name, type, detail FROM ("
+            + feature_grep(
+                ("sys_context",),
+                "UPPER(s.text) LIKE '%SYS_CONTEXT(%'"
+                " OR UPPER(s.text) LIKE '%USERENV(%'",
+                "SYS_CONTEXT",
+            )
+            + " UNION ALL"
+            " SELECT owner, name, 'VIEW DDL', 'SYS_CONTEXT in view definition'"
+            " AS detail FROM ddl WHERE type = 'VIEW'"
+            " AND (UPPER(ddl) LIKE '%SYS_CONTEXT(%' OR UPPER(ddl) LIKE '%USERENV(%'))"
+        ),
+    ),
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,7 +122,7 @@ def test_explain_lists_catalog() -> None:
     result = runner.invoke(app, ["explain"])
     assert result.exit_code == 0
     assert "R-TYPE-01" in result.output
-    assert "76 rules" in result.output
+    assert "79 rules" in result.output
 
 
 def test_explain_rejects_unknown_id() -> None:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -810,6 +810,19 @@ _RULE_FIXTURES = {
         "INSERT INTO features (feature, detail, count)"
         " VALUES ('external_tables', 'EXT', 1)"
     ),
+    "R-TYPE-08": (
+        "INSERT INTO columns (owner, table_name, column_name, data_type)"
+        " VALUES ('GIS', 'PARCELS', 'SHAPE', 'SDO_GEOMETRY')"
+    ),
+    "R-SRC-28": (
+        "INSERT INTO source (owner, name, type, line, text) VALUES"
+        " ('HR', 'WHO_AM_I', 'FUNCTION', 1,"
+        " 'RETURN SYS_CONTEXT(''USERENV'', ''SESSION_USER'');')"
+    ),
+    "R-OBJ-11": (
+        "INSERT INTO plsql_calls (owner, name, type, callee, line) VALUES"
+        " ('HR', 'SYNC_IT', 'PROCEDURE', 'REMOTE_PKG.LOG_IT@SALES_LINK', 7)"
+    ),
 }
 
 

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -15,6 +15,22 @@ def test_comments_and_strings_produce_no_features() -> None:
     assert [(f.feature, f.line) for f in analysis.features] == [("sysdate", 5)]
 
 
+def test_session_context_reads_are_features_not_columns() -> None:
+    unit = (
+        "FUNCTION who RETURN VARCHAR2 IS\n"
+        "  sys_context NUMBER := 1;  -- a column or variable, not a call\n"
+        "BEGIN\n"
+        "  RETURN SYS_CONTEXT('USERENV', 'SESSION_USER') || USERENV('SESSIONID');\n"
+        "END;"
+    )
+    analysis = analyze_source(unit)
+    assert analysis.errors == ()
+    context = [
+        (f.line, f.detail) for f in analysis.features if f.feature == "sys_context"
+    ]
+    assert context == [(4, "SYS_CONTEXT"), (4, "USERENV")]
+
+
 def test_statement_features_are_collected() -> None:
     unit = (
         "PROCEDURE p IS\n"


### PR DESCRIPTION
Three rules take the catalog from 76 to 79, part of the 0.7 consolidation train.

- **R-TYPE-08 Spatial column** (data types, high, extension postgis): `SDO_GEOMETRY` and the rest of the `SDO_%` family on columns.
- **R-SRC-28 Session context read** (sql, medium): `SYS_CONTEXT(` / `USERENV(` in stored code and in view DDL. Detected at the token level on the lexer's own keyword tokens, and only when a parenthesis follows, so a variable or column named `sys_context` is not a finding. New walker feature `sys_context` carries which function was called.
- **R-OBJ-11 Remote call over a database link** (objects, high, extension postgres_fdw): a callee with `@link` in the call graph, which `postgres_fdw` cannot serve since it reaches remote tables, not remote code.

Tests: three fixtures in the parametrized rule test, a walker test for the call-versus-identifier split, CLI count assertion to 79. Bundled sample headline numbers are unchanged (57 findings, 77.2 points).

README rule table and count updated; CHANGELOG Unreleased bullet added.