### PR TITLE
convert: fuzz the laws, fold names one way, lose nothing silently

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,84 @@
+name: Schema fuzz
+
+# Adversarial extraction dumps, generated from a seed, through load,
+# report, convert, and a live PostgreSQL apply; every seed must obey
+# the converter's laws. Nightly on a fresh window of seeds, and on
+# pull requests that touch the converter, the loader, or the fuzzer.
+
+on:
+  schedule:
+    - cron: "47 4 * * *"
+  workflow_dispatch:
+    inputs:
+      seeds:
+        description: "How many seeds"
+        default: "40"
+      start:
+        description: "First seed (blank: derived from the date)"
+        default: ""
+  pull_request:
+    paths:
+      - ".github/workflows/fuzz.yml"
+      - "tools/fuzz_*.py"
+      - "src/pgrecon/convert/**"
+      - "src/pgrecon/inventory/**"
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: ["16", "18"]
+    services:
+      postgres:
+        image: postgres:${{ matrix.pg }}
+        env:
+          POSTGRES_PASSWORD: ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Pick the seed window
+        id: window
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "start=1" >> "$GITHUB_OUTPUT"
+            echo "seeds=12" >> "$GITHUB_OUTPUT"
+          else
+            start="${{ github.event.inputs.start }}"
+            if [ -z "$start" ]; then
+              start=$(( $(date -u +%Y%m%d) % 100000 * 100 + 1 ))
+            fi
+            echo "start=$start" >> "$GITHUB_OUTPUT"
+            echo "seeds=${{ github.event.inputs.seeds || 40 }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fuzz against PostgreSQL ${{ matrix.pg }}
+        run: |
+          uv run python tools/fuzz_run.py \
+            --seeds ${{ steps.window.outputs.seeds }} \
+            --start ${{ steps.window.outputs.start }} \
+            --pg "host=127.0.0.1 user=postgres password=ci" \
+            --work fuzz-work
+
+      - name: Keep the failing seeds
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-failures-pg${{ matrix.pg }}
+          path: fuzz-work/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ htmlcov/
 *.db
 *.log
 dump/
+fuzz-work/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
   lowercase - so a table, its checks, comments, grants, triggers, and
   the views over it all spell it the same way. Trigger names and
   their tables are quoted when they need it.
+- From the live-apply law's first run, six more shapes that used to
+  ship as DDL PostgreSQL rejects now convert or decline by name: a
+  column default drawn from a sequence in the catalog's own spelling
+  becomes nextval over the converted sequence; EMPTY_CLOB and
+  EMPTY_BLOB defaults become empty values; a sequence whose last
+  value lies outside its bounds is declined instead of emitted with
+  an impossible START; partitioning by a virtual or unconverted
+  column is declined and the table emitted plain; TRUNC and ROUND
+  over a date column or date expression decline in defaults, index
+  expressions, and check conditions; an index expression that parses
+  as an alias declines instead of shipping as nonsense.
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,14 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
   column, and materialized views whose container repeats a column
   name; a multi-column range partition now bounds every key column
   in its floors and its open upper bound.
+- Expressions that lean on Oracle's implicit conversions decline where
+  the column types are known: UPPER over a NUMBER, NVL of a VARCHAR2
+  with 0, and their kin in defaults, virtual columns, index
+  expressions, and check conditions. HEXTORAW and RAWTOHEX become
+  decode and encode. Indexes and keys over XMLTYPE or JSON columns
+  decline, since the mapped types have no btree operator class, and a
+  unique index on a partitioned table declines unless it carries
+  every partition key column.
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,15 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
   decline, since the mapped types have no btree operator class, and a
   unique index on a partitioned table declines unless it carries
   every partition key column.
+- The top-N idiom converts: a ROWNUM bound that is a plain conjunct
+  of a query's WHERE becomes LIMIT on that query, in views and
+  materialized views; ROWNUM beside ORDER BY in the same query,
+  projected, or compared with a column declines by name. Cursor FOR
+  loops in converted routines get their loop variable declared as a
+  record, which PL/pgSQL requires and Oracle did by itself. TRUNC and
+  ROUND over a text column decline; an index expression naming a
+  column the table does not have declines; a grant option to PUBLIC
+  is dropped with a note, since PostgreSQL grants options to roles.
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
   ROUND over a text column decline; an index expression naming a
   column the table does not have declines; a grant option to PUBLIC
   is dropped with a note, since PostgreSQL grants options to roles.
+- Unique keys and unique indexes on a composite-partitioned table must
+  carry the subpartition key as well, since PostgreSQL's children are
+  partitioned tables themselves; a view over one table that names a
+  column the converted table does not have declines instead of
+  shipping a query PostgreSQL rejects.
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
   over a date column or date expression decline in defaults, index
   expressions, and check conditions; an index expression that parses
   as an alias declines instead of shipping as nonsense.
+- Foreign keys whose columns map to types PostgreSQL cannot compare
+  through the key (NUMBER against NUMBER(10) lands as numeric against
+  bigint, VARCHAR2 against CHAR as text against char), or whose column
+  count differs from the referenced key, decline by name. USER in an
+  expression becomes current_user; a default that refers to a column
+  or an untranslated pseudo-column, or a string literal longer than
+  its column, declines instead of shipping DDL PostgreSQL rejects.
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
   token level so a column named sys_context stays silent), and
   remote calls over a database link (a callee with @link, which
   postgres_fdw cannot serve).
+- A schema fuzzer guards the converter's laws: tools/fuzz_dump.py
+  generates adversarial extraction dumps from a seed and
+  tools/fuzz_run.py checks every seed for crashes, for objects that
+  left the inventory without reaching the DDL or the residue, and,
+  given a PostgreSQL, for rejected statements. A nightly job runs a
+  fresh window of seeds against PostgreSQL 16 and 18.
+- The fuzzer's first findings, fixed: a check constraint whose
+  condition never reached the inventory, a view whose DDL never
+  reached the dump, and a routine without source are now declined by
+  name instead of vanishing; the loader's DDL marker accepts names
+  with spaces; materialized views with case-sensitive names convert
+  under their catalog spelling.
+- One identifier convention across every emitter: a name Oracle
+  stored in uppercase folds to lowercase, a name created quoted with
+  lowercase letters keeps its case, and reserved words are quoted
+  lowercase - so a table, its checks, comments, grants, triggers, and
+  the views over it all spell it the same way. Trigger names and
+  their tables are quoted when they need it.
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
   expression becomes current_user; a default that refers to a column
   or an untranslated pseudo-column, or a string literal longer than
   its column, declines instead of shipping DDL PostgreSQL rejects.
+- Indexes and check conditions over a column the converted table does
+  not have decline by name, as do foreign keys whose referenced key
+  was itself declined, virtual columns that read another virtual
+  column, and materialized views whose container repeats a column
+  name; a multi-column range partition now bounds every key column
+  in its floors and its open upper bound.
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/README.md
+++ b/README.md
@@ -225,6 +225,19 @@ tools/make_scale_dump.py, so the measurement is reproducible.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the commit conventions and
 how to add a rule. Every rule lands with its fixture test.
 
+The converter's laws are fuzzed as well. tools/fuzz_dump.py generates
+an adversarial extraction dump from a seed - names past 63 bytes in
+ASCII and Hangul, names that collide once Oracle's namespaces fold
+into pg_class, reserved words as columns, every partition layout,
+spools carrying an Oracle error or a foreign code page - and
+tools/fuzz_run.py drives seeds through load, report, and convert,
+checking that nothing crashed, that every object the loader stored is
+either created in the DDL or named in the residue, and, given a
+PostgreSQL, that the DDL applies. CI runs a fresh window of seeds
+nightly against PostgreSQL 16 and 18 (fuzz.yml); locally:
+
+    uv run python tools/fuzz_run.py --seeds 10
+
 ## Commercial support
 
 The maintainer offers commercial migration assessment and delivery

--- a/src/pgrecon/convert/code.py
+++ b/src/pgrecon/convert/code.py
@@ -309,7 +309,7 @@ def _emit_code(
         (r["name"] or "").upper()
         for r in conn.execute("SELECT name FROM objects WHERE type = 'PACKAGE'")
     }
-    tables = {t for (_, t) in emitted}
+    tables = {t.upper() for (_, t) in emitted}
 
     for r in conn.execute(
         "SELECT owner, name FROM objects WHERE type = 'PACKAGE' ORDER BY owner, name"
@@ -342,6 +342,22 @@ def _emit_code(
         " FROM plsql_units WHERE type IN ('FUNCTION', 'PROCEDURE')"
         " ORDER BY owner, name"
     ).fetchall()
+    # A unit the catalog lists but whose source never reached the dump
+    # is declined by name rather than forgotten.
+    with_source = {(u["owner"], u["name"], u["type"]) for u in units}
+    for r in conn.execute(
+        "SELECT owner, name, type FROM objects"
+        " WHERE type IN ('FUNCTION', 'PROCEDURE') ORDER BY owner, name"
+    ):
+        if (r["owner"], r["name"], r["type"]) not in with_source:
+            residue.append(
+                Residue(
+                    r["owner"],
+                    r["name"],
+                    r["type"].lower(),
+                    "no source for this unit reached the dump; extract it by hand",
+                )
+            )
 
     accepted: dict[str, tuple[str, str, str, list[str]]] = {}
     edges: dict[str, set[str]] = {}

--- a/src/pgrecon/convert/constraints.py
+++ b/src/pgrecon/convert/constraints.py
@@ -5,6 +5,7 @@ import sqlite3
 
 from pgrecon.convert.identifiers import (
     _date_function_guard,
+    _default_guard,
     _fold_condition,
     _referenced_columns,
     ident,
@@ -239,7 +240,8 @@ def _emit_checks(
         date_guard = (
             None
             if folded is None
-            else _date_function_guard(
+            else _default_guard(folded)
+            or _date_function_guard(
                 folded, _date_columns(conn, r["owner"], r["table_name"])
             )
         )

--- a/src/pgrecon/convert/constraints.py
+++ b/src/pgrecon/convert/constraints.py
@@ -53,12 +53,16 @@ def _constraint_guard(
                 " class and cannot be a key on PostgreSQL"
             )
     if unique:
+        # Every level of the partition key, since the children are
+        # partitioned tables themselves.
         part_keys = [
             (r["column_name"] or "").upper()
             for r in conn.execute(
                 "SELECT column_name FROM part_key_columns"
+                " WHERE owner = ? AND table_name = ?"
+                " UNION ALL SELECT column_name FROM part_subkey_columns"
                 " WHERE owner = ? AND table_name = ?",
-                (owner, table),
+                (owner, table, owner, table),
             )
         ]
         cols = {c.upper() for c in raw_columns}

--- a/src/pgrecon/convert/constraints.py
+++ b/src/pgrecon/convert/constraints.py
@@ -4,6 +4,7 @@ import re
 import sqlite3
 
 from pgrecon.convert.identifiers import (
+    _date_function_guard,
     _fold_condition,
     _referenced_columns,
     ident,
@@ -11,6 +12,7 @@ from pgrecon.convert.identifiers import (
 )
 from pgrecon.convert.namespace import NameRegistry
 from pgrecon.convert.residue import Residue
+from pgrecon.convert.tables import _date_columns
 
 _NOT_NULL_CONDITION = re.compile(
     r'^"?[A-Za-z0-9_$#]+"?\s+IS\s+NOT\s+NULL$', re.IGNORECASE
@@ -234,13 +236,20 @@ def _emit_checks(
             )
             continue
         folded = _fold_condition(condition)
-        if folded is None:
+        date_guard = (
+            None
+            if folded is None
+            else _date_function_guard(
+                folded, _date_columns(conn, r["owner"], r["table_name"])
+            )
+        )
+        if folded is None or date_guard is not None:
             residue.append(
                 Residue(
                     r["owner"],
                     r["constraint_name"],
                     "check",
-                    "condition could not be translated; port it by hand",
+                    date_guard or "condition could not be translated; port it by hand",
                 )
             )
             continue

--- a/src/pgrecon/convert/constraints.py
+++ b/src/pgrecon/convert/constraints.py
@@ -8,13 +8,14 @@ from pgrecon.convert.identifiers import (
     _default_guard,
     _fold_condition,
     _referenced_columns,
+    _type_mismatch_guard,
     ident,
     over_limit,
 )
 from pgrecon.convert.namespace import NameRegistry
 from pgrecon.convert.residue import Residue
-from pgrecon.convert.tables import _date_columns
-from pgrecon.convert.typemap import fk_compatible, map_type
+from pgrecon.convert.tables import _column_families, _date_columns
+from pgrecon.convert.typemap import fk_compatible, indexable, map_type
 
 _NOT_NULL_CONDITION = re.compile(
     r'^"?[A-Za-z0-9_$#]+"?\s+IS\s+NOT\s+NULL$', re.IGNORECASE
@@ -43,6 +44,14 @@ def _constraint_guard(
     missing = [c for c in raw_columns if c.upper() not in emitted[(owner, table)]]
     if missing:
         return f"column {missing[0]} was not converted"
+    for col, pg_type in zip(
+        raw_columns, _mapped_types(conn, owner, table, raw_columns), strict=True
+    ):
+        if pg_type is not None and not indexable(pg_type):
+            return (
+                f"column {col} lands as {pg_type}, which has no btree operator"
+                " class and cannot be a key on PostgreSQL"
+            )
     if unique:
         part_keys = [
             (r["column_name"] or "").upper()
@@ -310,6 +319,9 @@ def _emit_checks(
             else _default_guard(folded)
             or _date_function_guard(
                 folded, _date_columns(conn, r["owner"], r["table_name"])
+            )
+            or _type_mismatch_guard(
+                folded, _column_families(conn, r["owner"], r["table_name"])
             )
         )
         if folded is None or date_guard is not None:

--- a/src/pgrecon/convert/constraints.py
+++ b/src/pgrecon/convert/constraints.py
@@ -177,14 +177,28 @@ def _emit_checks(
     count = 0
     rows = conn.execute(
         "SELECT c.owner, c.constraint_name, c.table_name, k.condition, k.truncated"
-        " FROM constraints c JOIN check_conditions k"
+        " FROM constraints c LEFT JOIN check_conditions k"
         " ON k.owner = c.owner AND k.constraint_name = c.constraint_name"
         " WHERE c.type = 'C' ORDER BY c.owner, c.table_name, c.constraint_name"
     ).fetchall()
     wrote = False
     for r in rows:
         condition = (r["condition"] or "").strip()
-        if not condition or _NOT_NULL_CONDITION.match(condition):
+        if not condition:
+            # Conditions travel through their own spool, read from a
+            # LONG; a constraint whose text never arrived is declined
+            # by name, not forgotten.
+            residue.append(
+                Residue(
+                    r["owner"],
+                    r["constraint_name"],
+                    "check",
+                    "its condition was not captured in the inventory;"
+                    " recover it from the source before porting",
+                )
+            )
+            continue
+        if _NOT_NULL_CONDITION.match(condition):
             # Column-level NOT NULL already lives on the column.
             continue
         if matviews and (r["table_name"] or "").upper() in matviews:

--- a/src/pgrecon/convert/constraints.py
+++ b/src/pgrecon/convert/constraints.py
@@ -147,8 +147,11 @@ def _emit_keys(
     emitted: dict[tuple[str, str], set[str]],
     names: NameRegistry,
     matviews: set[str] | None = None,
-) -> int:
+) -> tuple[int, set[tuple[str, str]]]:
+    """Primary and unique keys; returns the count and the (owner, name)
+    pairs that were actually emitted, which foreign keys must point at."""
     count = 0
+    created: set[tuple[str, str]] = set()
     rows = conn.execute(
         "SELECT owner, constraint_name, table_name, type FROM constraints"
         " WHERE type IN ('P', 'U') ORDER BY type, owner, table_name, constraint_name"
@@ -225,10 +228,11 @@ def _emit_keys(
             f"ALTER TABLE {ident(r['table_name'])} ADD CONSTRAINT"
             f" {name} {kind} ({cols});"
         )
+        created.add((r["owner"], r["constraint_name"]))
         count += 1
     if rows:
         out.append("")
-    return count
+    return count, created
 
 
 def _emit_checks(
@@ -337,6 +341,19 @@ def _emit_checks(
                 )
             )
             continue
+        present = {c.upper() for c in emitted[(r["owner"], r["table_name"])]}
+        unknown = sorted(referenced - present)
+        if unknown:
+            residue.append(
+                Residue(
+                    r["owner"],
+                    r["constraint_name"],
+                    "check",
+                    f"condition references {unknown[0]}, which is not a column"
+                    " of the converted table",
+                )
+            )
+            continue
         if not names.claim(
             r["constraint_name"] or "",
             "check",
@@ -363,6 +380,7 @@ def _emit_foreign_keys(
     emitted: dict[tuple[str, str], set[str]],
     names: NameRegistry,
     matviews: set[str] | None = None,
+    emitted_keys: set[tuple[str, str]] | None = None,
 ) -> int:
     count = 0
     rows = conn.execute(
@@ -411,6 +429,20 @@ def _emit_foreign_keys(
                     "foreign key",
                     "references a materialized view, which cannot carry"
                     " the referenced unique constraint in PostgreSQL",
+                )
+            )
+            continue
+        if (
+            emitted_keys is not None
+            and (r["ref_owner"], r["ref_constraint"]) not in emitted_keys
+        ):
+            residue.append(
+                Residue(
+                    r["owner"],
+                    r["constraint_name"],
+                    "foreign key",
+                    f"the referenced key {r['ref_constraint']} was not"
+                    " converted, so there is nothing to point at",
                 )
             )
             continue

--- a/src/pgrecon/convert/constraints.py
+++ b/src/pgrecon/convert/constraints.py
@@ -14,6 +14,7 @@ from pgrecon.convert.identifiers import (
 from pgrecon.convert.namespace import NameRegistry
 from pgrecon.convert.residue import Residue
 from pgrecon.convert.tables import _date_columns
+from pgrecon.convert.typemap import fk_compatible, map_type
 
 _NOT_NULL_CONDITION = re.compile(
     r'^"?[A-Za-z0-9_$#]+"?\s+IS\s+NOT\s+NULL$', re.IGNORECASE
@@ -59,6 +60,68 @@ def _constraint_guard(
                 " partitioned table to include every partition key;"
                 f" {uncovered[0]} is missing - widen the key or"
                 " enforce uniqueness another way"
+            )
+    return None
+
+
+def _mapped_types(
+    conn: sqlite3.Connection, owner: str, table: str, columns: list[str]
+) -> list[str | None]:
+    types: list[str | None] = []
+    for name in columns:
+        row = conn.execute(
+            "SELECT data_type, data_length, data_precision, data_scale FROM columns"
+            " WHERE owner = ? AND table_name = ? AND UPPER(column_name) = ?",
+            (owner, table, name.upper()),
+        ).fetchone()
+        if row is None:
+            types.append(None)
+            continue
+        types.append(
+            map_type(
+                row["data_type"],
+                row["data_length"],
+                row["data_precision"],
+                row["data_scale"],
+            ).pg_type
+        )
+    return types
+
+
+def _fk_type_guard(
+    conn: sqlite3.Connection,
+    owner: str,
+    table: str,
+    columns: list[str],
+    ref_owner: str,
+    ref_table: str,
+    ref_columns: list[str],
+) -> str | None:
+    """Why a foreign key cannot be implemented on PostgreSQL, or None.
+
+    Oracle checks that referencing and referenced columns are
+    compatible in its own type system; after mapping, a NUMBER child
+    against a NUMBER(10) parent is numeric against bigint, which
+    PostgreSQL rejects, and a column count that differs from the
+    referenced key never applied anywhere.
+    """
+    if len(columns) != len(ref_columns):
+        return (
+            f"{len(columns)} columns reference a key of {len(ref_columns)};"
+            " the constraint facts disagree - recreate it from the source"
+        )
+    child_types = _mapped_types(conn, owner, table, columns)
+    parent_types = _mapped_types(conn, ref_owner, ref_table, ref_columns)
+    for col, child, ref_col, parent in zip(
+        columns, child_types, ref_columns, parent_types, strict=True
+    ):
+        if child is None or parent is None:
+            continue
+        if not fk_compatible(child, parent):
+            return (
+                f"column {col} maps to {child} while the referenced {ref_col}"
+                f" maps to {parent}; PostgreSQL cannot compare them through"
+                " the key - align the types by hand"
             )
     return None
 
@@ -351,10 +414,22 @@ def _emit_foreign_keys(
                 )
             )
             continue
-        reason = _constraint_guard(
-            conn, r["owner"], r["table_name"], raw, emitted, unique=False
-        ) or _constraint_guard(
-            conn, r["ref_owner"], ref["table_name"], ref_raw, emitted, unique=False
+        reason = (
+            _constraint_guard(
+                conn, r["owner"], r["table_name"], raw, emitted, unique=False
+            )
+            or _constraint_guard(
+                conn, r["ref_owner"], ref["table_name"], ref_raw, emitted, unique=False
+            )
+            or _fk_type_guard(
+                conn,
+                r["owner"],
+                r["table_name"],
+                raw,
+                r["ref_owner"],
+                ref["table_name"],
+                ref_raw,
+            )
         )
         if reason is not None:
             residue.append(

--- a/src/pgrecon/convert/extras.py
+++ b/src/pgrecon/convert/extras.py
@@ -268,7 +268,7 @@ def _emit_comments(
         kept = emitted.get((r["owner"], raw))
         if name in matviews or name in created_views:
             pass  # matview and view columns exist; comment applies
-        elif kept is None or raw_col not in kept:
+        elif kept is None or raw_col.upper() not in kept:
             continue
         text = (r["comments"] or "").replace("'", "''")
         out.append(f"COMMENT ON COLUMN {ident(raw)}.{ident(raw_col)} IS '{text}';")

--- a/src/pgrecon/convert/extras.py
+++ b/src/pgrecon/convert/extras.py
@@ -51,10 +51,24 @@ def _emit_sequences(
             continue
         parts = [f"CREATE SEQUENCE {ident(r['sequence_name'])}"]
         parts.append(f"INCREMENT BY {fields['increment_by']}")
-        if abs(int(fields["min_value"])) <= _PG_BIGINT_MAX:
-            parts.append(f"MINVALUE {fields['min_value']}")
-        if fields["max_value"] and int(fields["max_value"]) <= _PG_BIGINT_MAX:
-            parts.append(f"MAXVALUE {fields['max_value']}")
+        # Bounds past bigint mean unbounded and are left to PostgreSQL's
+        # defaults; the start value is checked against the bounds that
+        # will actually be enforced.
+        increment = int(fields["increment_by"])
+        low_raw = int(fields["min_value"])
+        low = low_raw if abs(low_raw) <= _PG_BIGINT_MAX else None
+        high_raw = int(fields["max_value"]) if fields["max_value"] else None
+        high = high_raw if high_raw is not None and high_raw <= _PG_BIGINT_MAX else None
+        if low is not None:
+            parts.append(f"MINVALUE {low}")
+        if high is not None:
+            parts.append(f"MAXVALUE {high}")
+        floor = (
+            low if low is not None else (1 if increment > 0 else -_PG_BIGINT_MAX - 1)
+        )
+        ceiling = (
+            high if high is not None else (_PG_BIGINT_MAX if increment > 0 else -1)
+        )
         start = int(fields["last_number"])
         if start > _PG_BIGINT_MAX:
             residue.append(
@@ -63,6 +77,18 @@ def _emit_sequences(
                     r["sequence_name"],
                     "sequence",
                     "current value exceeds bigint; recreate by hand",
+                )
+            )
+            continue
+        if not floor <= start <= ceiling:
+            residue.append(
+                Residue(
+                    r["owner"],
+                    r["sequence_name"],
+                    "sequence",
+                    f"last value {start} lies outside its bounds {floor} to {ceiling}:"
+                    " the sequence is exhausted on Oracle, or the facts"
+                    " disagree - recreate by hand",
                 )
             )
             continue

--- a/src/pgrecon/convert/extras.py
+++ b/src/pgrecon/convert/extras.py
@@ -364,6 +364,18 @@ def _emit_grants(
             continue
         target = "PUBLIC" if grantee == "PUBLIC" else ident(r["grantee"] or "")
         option = " WITH GRANT OPTION" if (r["grantable"] or "").upper() == "YES" else ""
+        if option and target == "PUBLIC":
+            # PostgreSQL grants options to roles only.
+            option = ""
+            residue.append(
+                Residue(
+                    r["owner"],
+                    f"{name}.{priv}->PUBLIC",
+                    "note",
+                    "grant option to PUBLIC dropped; PostgreSQL grants options"
+                    " to roles only",
+                )
+            )
         out.append(f"GRANT {mapped} ON {kind}{ident(raw)} TO {target}{option};")
         count += 1
     if count or grantees:

--- a/src/pgrecon/convert/extras.py
+++ b/src/pgrecon/convert/extras.py
@@ -3,7 +3,7 @@
 import re
 import sqlite3
 
-from pgrecon.convert.identifiers import ident
+from pgrecon.convert.identifiers import fold_case, ident
 from pgrecon.convert.namespace import NameRegistry
 from pgrecon.convert.residue import Residue
 
@@ -101,7 +101,7 @@ def _emit_synonyms(
         "SELECT owner, synonym_name, table_owner, table_name, db_link"
         " FROM synonyms ORDER BY owner, synonym_name"
     ).fetchall()
-    known = {t for (_, t) in emitted} | created_views
+    known = {t.upper() for (_, t) in emitted} | created_views
     count = 0
     created: set[str] = set()
     for r in rows:
@@ -215,11 +215,12 @@ def _emit_comments(
     nothing.
     """
     count = 0
-    tables = {t for (_, t) in emitted}
+    tables = {t.upper() for (_, t) in emitted}
     for r in conn.execute(
         "SELECT owner, table_name, comments FROM table_comments ORDER BY table_name"
     ):
-        name = (r["table_name"] or "").upper()
+        raw = r["table_name"] or ""
+        name = raw.upper()
         text = (r["comments"] or "").replace("'", "''")
         if name in matviews:
             kind = "MATERIALIZED VIEW"
@@ -229,23 +230,22 @@ def _emit_comments(
             kind = "TABLE"
         else:
             continue
-        out.append(f"COMMENT ON {kind} {ident(name.lower())} IS '{text}';")
+        out.append(f"COMMENT ON {kind} {ident(raw)} IS '{text}';")
         count += 1
     for r in conn.execute(
         "SELECT owner, table_name, column_name, comments FROM column_comments"
         " ORDER BY table_name, column_name"
     ):
-        name = (r["table_name"] or "").upper()
-        col = (r["column_name"] or "").upper()
-        kept = emitted.get((r["owner"], name))
+        raw = r["table_name"] or ""
+        raw_col = r["column_name"] or ""
+        name = raw.upper()
+        kept = emitted.get((r["owner"], raw))
         if name in matviews or name in created_views:
             pass  # matview and view columns exist; comment applies
-        elif kept is None or col not in kept:
+        elif kept is None or raw_col not in kept:
             continue
         text = (r["comments"] or "").replace("'", "''")
-        out.append(
-            f"COMMENT ON COLUMN {ident(name.lower())}.{ident(col.lower())} IS '{text}';"
-        )
+        out.append(f"COMMENT ON COLUMN {ident(raw)}.{ident(raw_col)} IS '{text}';")
         count += 1
     if count:
         out.append("")
@@ -289,19 +289,20 @@ def _emit_grants(
     ).fetchall()
     if not rows:
         return 0
-    tables = {t for (_, t) in emitted}
-    known = tables | matviews | created_views | sequence_names
+    tables = {t.upper() for (_, t) in emitted}
+    sequences = {s.upper() for s in sequence_names}
+    known = tables | matviews | created_views | sequences
     grantees = sorted(
         {
-            (r["grantee"] or "").upper()
+            fold_case(r["grantee"] or "")
             for r in rows
             if (r["grantee"] or "").upper() != "PUBLIC"
             and (r["table_name"] or "").upper() in known
         }
     )
     for grantee in grantees:
-        role = ident(grantee.lower())
-        quoted = grantee.lower().replace("'", "''")
+        role = ident(grantee)
+        quoted = grantee.replace("'", "''")
         out.append(
             "DO $$ BEGIN\n"
             f"  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '{quoted}')"
@@ -312,12 +313,13 @@ def _emit_grants(
         )
     count = 0
     for r in rows:
-        name = (r["table_name"] or "").upper()
+        raw = r["table_name"] or ""
+        name = raw.upper()
         priv = (r["privilege"] or "").upper()
         grantee = (r["grantee"] or "").upper()
         if name not in known:
             continue  # the object's absence is already named
-        if name in sequence_names:
+        if name in sequences:
             mapped = _SEQUENCE_PRIVS.get(priv)
             kind = "SEQUENCE "
         else:
@@ -334,11 +336,9 @@ def _emit_grants(
                 )
             )
             continue
-        target = "PUBLIC" if grantee == "PUBLIC" else ident(grantee.lower())
+        target = "PUBLIC" if grantee == "PUBLIC" else ident(r["grantee"] or "")
         option = " WITH GRANT OPTION" if (r["grantable"] or "").upper() == "YES" else ""
-        out.append(
-            f"GRANT {mapped} ON {kind}{ident(name.lower())} TO {target}{option};"
-        )
+        out.append(f"GRANT {mapped} ON {kind}{ident(raw)} TO {target}{option};")
         count += 1
     if count or grantees:
         out.append("")

--- a/src/pgrecon/convert/identifiers.py
+++ b/src/pgrecon/convert/identifiers.py
@@ -89,12 +89,26 @@ _RESERVED = {
 }
 
 
+def fold_case(name: str) -> str:
+    """The spelling PostgreSQL will know the name by.
+
+    Oracle stores a name created without quotes in uppercase and
+    matches it case-insensitively; PostgreSQL does the same in
+    lowercase, so those fold. A name carrying lowercase letters was
+    created quoted and case-sensitive on Oracle and keeps its
+    spelling exactly. Every emitter goes through this one rule, so a
+    table, its comments, its grants, its checks, and the views over
+    it all spell the name the same way.
+    """
+    return name.lower() if name == name.upper() else name
+
+
 def ident(name: str) -> str:
-    """Fold to lowercase; quote only when the result needs it."""
-    lowered = name.lower()
-    if _PLAIN_IDENT.match(lowered) and lowered not in _RESERVED:
-        return lowered
-    return '"' + name.replace('"', '""') + '"'
+    """Fold to PostgreSQL's case; quote only when the result needs it."""
+    folded = fold_case(name)
+    if _PLAIN_IDENT.match(folded) and folded not in _RESERVED:
+        return folded
+    return '"' + folded.replace('"', '""') + '"'
 
 
 # PostgreSQL truncates identifiers to 63 bytes at parse time, quoted
@@ -124,7 +138,7 @@ def truncation_clash(names: Iterable[str]) -> tuple[str, str] | None:
     """The first pair of names PostgreSQL would fold together, if any."""
     seen: dict[str, str] = {}
     for name in names:
-        key = pg_truncate(name.lower())
+        key = pg_truncate(fold_case(name))
         prior = seen.get(key)
         if prior is not None and prior != name:
             return prior, name
@@ -145,11 +159,13 @@ def _concat_parts(node: Expr) -> list[Expr]:
 
 
 def _fold_identifiers(tree: Expr) -> Expr:
-    """Lowercase and unquote identifiers; drop schema qualifiers.
+    """Fold identifiers to the converter's spelling; drop schema qualifiers.
 
     DBMS_METADATA quotes every identifier in uppercase; carried as-is
     the view would reference "EMP" while the converted table is emp.
-    Single-schema conversion also drops the owner prefix.
+    The fold is the same one ident() applies to DDL, so case-sensitive
+    and reserved names come out spelled exactly as their objects were
+    created. Single-schema conversion also drops the owner prefix.
 
     Concatenation chains become NULLIF(concat(...), ''): Oracle ||
     treats NULL as the empty string where PostgreSQL || yields NULL,
@@ -160,8 +176,9 @@ def _fold_identifiers(tree: Expr) -> Expr:
     """
     for node in tree.walk():
         if isinstance(node, exp.Identifier):
-            node.set("this", node.name.lower())
-            node.set("quoted", not _PLAIN_IDENT.match(node.name.lower()))
+            folded = fold_case(node.name)
+            node.set("this", folded)
+            node.set("quoted", not _PLAIN_IDENT.match(folded) or folded in _RESERVED)
         if isinstance(node, exp.Table | exp.Column) and node.args.get("db"):
             node.set("db", None)
     chains = [

--- a/src/pgrecon/convert/identifiers.py
+++ b/src/pgrecon/convert/identifiers.py
@@ -233,7 +233,13 @@ def _fold_expression(expression: str) -> str | None:
         select = _fold_identifiers(tree).find(exp.Select)
         if select is None or not select.expressions:
             return None
-        return str(select.expressions[0].sql(dialect="postgres"))
+        head = select.expressions[0]
+        if isinstance(head, exp.Alias) or len(select.expressions) != 1:
+            # An index expression is one expression; a trailing DESC or
+            # a stray comma parses as an alias or a second column and
+            # would ship as nonsense.
+            return None
+        return str(head.sql(dialect="postgres"))
     except SqlglotError:
         return None
 
@@ -308,6 +314,53 @@ def _default_guard(folded: str) -> str | None:
                     "TO_DATE over a non-literal has no matching"
                     " PostgreSQL signature; rewrite it by hand"
                 )
+    return None
+
+
+_DATE_SOURCES = {
+    "CURRENT_TIMESTAMP",
+    "CURRENT_DATE",
+    "NOW",
+    "TO_DATE",
+    "TO_TIMESTAMP",
+    "STR_TO_DATE",
+    "LOCALTIMESTAMP",
+}
+
+
+def _date_function_guard(folded: str, date_columns: set[str]) -> str | None:
+    """Why a folded expression misuses a date, or None.
+
+    Oracle TRUNC and ROUND accept dates; PostgreSQL's do not, and the
+    fold cannot know a column's type. Callers pass the table's date
+    and timestamp columns so TRUNC(created) declines by name instead
+    of shipping DDL the server rejects; a date function as the
+    argument declines the same way.
+    """
+    tree = _reparse(folded)
+    if tree is None:
+        return None
+    for node in tree.walk():
+        name = _func_name(node)
+        if name not in ("TRUNC", "ROUND"):
+            continue
+        if isinstance(node, exp.Anonymous):
+            first = node.expressions[0] if node.expressions else None
+        else:
+            first = node.args.get("this")
+        if isinstance(first, exp.Column) and first.name.upper() in date_columns:
+            return (
+                f"{name} over date column {first.name.upper()} has no PostgreSQL"
+                " counterpart; use date_trunc by hand"
+            )
+        if first is not None and (
+            _func_name(first) in _DATE_SOURCES
+            or isinstance(first, exp.CurrentTimestamp | exp.CurrentDate)
+        ):
+            return (
+                f"{name} over a date expression has no PostgreSQL counterpart;"
+                " use date_trunc by hand"
+            )
     return None
 
 

--- a/src/pgrecon/convert/identifiers.py
+++ b/src/pgrecon/convert/identifiers.py
@@ -534,10 +534,12 @@ def _type_mismatch_guard(folded: str, families: dict[str, str]) -> str | None:
         return None
     for node in tree.walk():
         name = _func_name(node)
-        if name in _TEXT_FUNCS or name in _NUMBER_FUNCS:
+        if name in _TEXT_FUNCS or name in _NUMBER_FUNCS or name in ("TRUNC", "ROUND"):
             first = _first_argument(node)
             family = _family_of(first, families) if first is not None else None
             wanted = "text" if name in _TEXT_FUNCS else "number"
+            if name in ("TRUNC", "ROUND") and family == "datetime":
+                continue  # the date guard owns that case
             if (
                 isinstance(first, exp.Column)
                 and family is not None

--- a/src/pgrecon/convert/identifiers.py
+++ b/src/pgrecon/convert/identifiers.py
@@ -158,6 +158,77 @@ def _concat_parts(node: Expr) -> list[Expr]:
     return [node]
 
 
+# Oracle TRUNC(date, format) formats that name a date_trunc field.
+# Week formats other than ISO, day-of-week formats, and ISO years have
+# no field and decline.
+_TRUNC_UNITS = {
+    "CC": "century",
+    "SCC": "century",
+    "SYYYY": "year",
+    "YYYY": "year",
+    "YEAR": "year",
+    "SYEAR": "year",
+    "YYY": "year",
+    "YY": "year",
+    "Y": "year",
+    "Q": "quarter",
+    "MONTH": "month",
+    "MON": "month",
+    "MM": "month",
+    "RM": "month",
+    "IW": "week",
+    "DDD": "day",
+    "DD": "day",
+    "J": "day",
+    "HH": "hour",
+    "HH12": "hour",
+    "HH24": "hour",
+    "MI": "minute",
+}
+_PG_TRUNC_FIELDS = {
+    "microseconds",
+    "milliseconds",
+    "second",
+    "minute",
+    "hour",
+    "day",
+    "week",
+    "month",
+    "quarter",
+    "year",
+    "decade",
+    "century",
+    "millennium",
+}
+
+
+def _trunc_unit_guard(tree: Expr) -> str | None:
+    """Why a date truncation cannot ship, or None.
+
+    sqlglot turns Oracle TRUNC over a date into date_trunc but keeps
+    the Oracle format string; the fold maps the formats that have a
+    field, and whatever is left has none.
+    """
+    for node in tree.walk():
+        if isinstance(node, exp.DateTrunc | exp.TimestampTrunc):
+            unit = node.args.get("unit")
+        elif _func_name(node) == "DATE_TRUNC" and isinstance(node, exp.Anonymous):
+            # The postgres dialect re-reads an unknown field as a plain
+            # call; the first argument is the field.
+            unit = node.expressions[0] if node.expressions else None
+        else:
+            continue
+        # A literal on the Oracle side, a bare field name once the
+        # postgres dialect has re-read its own output.
+        text = unit.name if unit is not None else ""
+        if text.lower() not in _PG_TRUNC_FIELDS:
+            return (
+                f"TRUNC format '{text}' has no date_trunc field in"
+                " PostgreSQL; rewrite it by hand"
+            )
+    return None
+
+
 def _fold_identifiers(tree: Expr) -> Expr:
     """Fold identifiers to the converter's spelling; drop schema qualifiers.
 
@@ -181,6 +252,12 @@ def _fold_identifiers(tree: Expr) -> Expr:
             node.set("quoted", not _PLAIN_IDENT.match(folded) or folded in _RESERVED)
         if isinstance(node, exp.Table | exp.Column) and node.args.get("db"):
             node.set("db", None)
+        if isinstance(node, exp.DateTrunc | exp.TimestampTrunc):
+            unit = node.args.get("unit")
+            if isinstance(unit, exp.Literal) and unit.is_string:
+                mapped = _TRUNC_UNITS.get(str(unit.this).upper())
+                if mapped is not None:
+                    unit.set("this", mapped)
     chains = [
         node
         for node in tree.walk()
@@ -230,7 +307,13 @@ def _fold_expression(expression: str) -> str | None:
         tree = parsed[0] if parsed else None
         if tree is None:
             return None
-        select = _fold_identifiers(tree).find(exp.Select)
+        folded = _fold_identifiers(tree)
+        if _trunc_unit_guard(folded) is not None:
+            # The postgres dialect normalizes unknown fields when it
+            # re-reads its own output, so the check runs here, on the
+            # Oracle-side tree, or not at all.
+            return None
+        select = folded.find(exp.Select)
         if select is None or not select.expressions:
             return None
         head = select.expressions[0]
@@ -256,7 +339,10 @@ def _fold_condition(condition: str) -> str | None:
         tree = parsed[0] if parsed else None
         if tree is None:
             return None
-        where = _fold_identifiers(tree).find(exp.Where)
+        folded = _fold_identifiers(tree)
+        if _trunc_unit_guard(folded) is not None:
+            return None
+        where = folded.find(exp.Where)
         if where is None:
             return None
         return str(where.this.sql(dialect="postgres"))
@@ -297,6 +383,9 @@ def _default_guard(folded: str) -> str | None:
     tree = _reparse(folded)
     if tree is None:
         return "expression could not be re-checked; rewrite it by hand"
+    unit_guard = _trunc_unit_guard(tree)
+    if unit_guard is not None:
+        return unit_guard
     for node in tree.walk():
         name = _func_name(node)
         if name in _UNSUPPORTED_EXPR_FUNCS or name.startswith("SYS_OP_"):

--- a/src/pgrecon/convert/identifiers.py
+++ b/src/pgrecon/convert/identifiers.py
@@ -245,6 +245,18 @@ def _fold_identifiers(tree: Expr) -> Expr:
     The concat call is emitted anonymously because sqlglot renders its
     own Concat node back to || on the postgres dialect.
     """
+    # Oracle's USER is a function spelled like a column; a column that
+    # is really named USER arrives quoted from the catalog and stays.
+    # It runs before the fold, which would quote the reserved word.
+    for node in list(tree.walk()):
+        if (
+            isinstance(node, exp.Column)
+            and node.name.upper() == "USER"
+            and not node.args.get("table")
+            and isinstance(node.this, exp.Identifier)
+            and not node.this.quoted
+        ):
+            node.replace(exp.CurrentUser())
     for node in tree.walk():
         if isinstance(node, exp.Identifier):
             folded = fold_case(node.name)
@@ -449,6 +461,26 @@ def _date_function_guard(folded: str, date_columns: set[str]) -> str | None:
             return (
                 f"{name} over a date expression has no PostgreSQL counterpart;"
                 " use date_trunc by hand"
+            )
+    return None
+
+
+def _default_column_guard(folded: str) -> str | None:
+    """Why a column default cannot ship, or None.
+
+    A default cannot read other columns on PostgreSQL, and every Oracle
+    pseudo-column the fold did not translate - UID, ROWNUM, LEVEL -
+    reaches here looking like one.
+    """
+    tree = _reparse(folded)
+    if tree is None:
+        return None
+    for node in tree.walk():
+        if isinstance(node, exp.Column):
+            return (
+                f"default refers to {node.name.upper()}, a column or Oracle"
+                " pseudo-column; PostgreSQL defaults cannot - choose a"
+                " replacement by hand"
             )
     return None
 

--- a/src/pgrecon/convert/identifiers.py
+++ b/src/pgrecon/convert/identifiers.py
@@ -245,6 +245,25 @@ def _fold_identifiers(tree: Expr) -> Expr:
     The concat call is emitted anonymously because sqlglot renders its
     own Concat node back to || on the postgres dialect.
     """
+    # Oracle's raw conversions have PostgreSQL spellings.
+    for node in list(tree.walk()):
+        if not isinstance(node, exp.Anonymous) or not node.expressions:
+            continue
+        name = str(node.this).upper()
+        if name == "HEXTORAW":
+            node.replace(
+                exp.Anonymous(
+                    this="decode",
+                    expressions=[node.expressions[0], exp.Literal.string("hex")],
+                )
+            )
+        elif name == "RAWTOHEX":
+            node.replace(
+                exp.Anonymous(
+                    this="encode",
+                    expressions=[node.expressions[0], exp.Literal.string("hex")],
+                )
+            )
     # Oracle's USER is a function spelled like a column; a column that
     # is really named USER arrives quoted from the catalog and stays.
     # It runs before the fold, which would quote the reserved word.
@@ -462,6 +481,85 @@ def _date_function_guard(folded: str, date_columns: set[str]) -> str | None:
                 f"{name} over a date expression has no PostgreSQL counterpart;"
                 " use date_trunc by hand"
             )
+    return None
+
+
+_TEXT_FUNCS = {
+    "UPPER",
+    "LOWER",
+    "INITCAP",
+    "TRIM",
+    "LTRIM",
+    "RTRIM",
+    "LENGTH",
+    "SUBSTR",
+    "SUBSTRING",
+    "INSTR",
+    "STRPOS",
+    "REPLACE",
+    "LPAD",
+    "RPAD",
+    "TRANSLATE",
+    "REGEXP_LIKE",
+    "REGEXP_REPLACE",
+    "REGEXP_SUBSTR",
+}
+_NUMBER_FUNCS = {"ABS", "FLOOR", "CEIL", "CEILING", "MOD", "POWER", "SQRT", "SIGN"}
+
+
+def _first_argument(node: Expr) -> Expr | None:
+    if isinstance(node, exp.Anonymous):
+        return node.expressions[0] if node.expressions else None
+    return node.args.get("this")
+
+
+def _family_of(node: Expr, families: dict[str, str]) -> str | None:
+    if isinstance(node, exp.Column):
+        return families.get(node.name.upper())
+    if isinstance(node, exp.Literal):
+        return "text" if node.is_string else "number"
+    return None
+
+
+def _type_mismatch_guard(folded: str, families: dict[str, str]) -> str | None:
+    """Why an expression leans on Oracle's implicit conversions, or None.
+
+    Oracle upper-cases a NUMBER and coalesces a VARCHAR2 with 0 by
+    converting silently; PostgreSQL refuses both. The callers pass the
+    table's column families so the expression is checked where the
+    types are known, and declines by name instead of shipping.
+    """
+    tree = _reparse(folded)
+    if tree is None:
+        return None
+    for node in tree.walk():
+        name = _func_name(node)
+        if name in _TEXT_FUNCS or name in _NUMBER_FUNCS:
+            first = _first_argument(node)
+            family = _family_of(first, families) if first is not None else None
+            wanted = "text" if name in _TEXT_FUNCS else "number"
+            if (
+                isinstance(first, exp.Column)
+                and family is not None
+                and family != wanted
+            ):
+                return (
+                    f"{name} over {family} column {first.name.upper()} relies on"
+                    " Oracle's implicit conversion; cast it explicitly by hand"
+                )
+        if isinstance(node, exp.Coalesce):
+            seen = {
+                f
+                for f in (
+                    _family_of(arg, families) for arg in [node.this, *node.expressions]
+                )
+                if f is not None
+            }
+            if len(seen) > 1:
+                return (
+                    "COALESCE mixes " + " and ".join(sorted(seen)) + "; Oracle"
+                    " converted implicitly, PostgreSQL will not - cast by hand"
+                )
     return None
 
 

--- a/src/pgrecon/convert/indexes.py
+++ b/src/pgrecon/convert/indexes.py
@@ -114,6 +114,11 @@ def _emit_indexes(
                     " recreate the index from the source"
                 )
                 break
+            elif (c["column_name"] or "").upper() not in {
+                k.upper() for k in emitted[(r["owner"], r["table_name"])]
+            }:
+                skip_reason = f"column {c['column_name']} was not converted"
+                break
             else:
                 parts.append(ident(c["column_name"]))
         if skip_reason is not None or not parts:

--- a/src/pgrecon/convert/indexes.py
+++ b/src/pgrecon/convert/indexes.py
@@ -3,6 +3,7 @@
 import sqlite3
 
 from pgrecon.convert.identifiers import (
+    _date_function_guard,
     _default_guard,
     _fold_expression,
     ident,
@@ -10,6 +11,7 @@ from pgrecon.convert.identifiers import (
 )
 from pgrecon.convert.namespace import NameRegistry
 from pgrecon.convert.residue import Residue
+from pgrecon.convert.tables import _date_columns
 
 
 def _emit_indexes(
@@ -91,7 +93,14 @@ def _emit_indexes(
                     )
                     break
                 folded = _fold_expression(expression)
-                guard = None if folded is None else _default_guard(folded)
+                guard = (
+                    None
+                    if folded is None
+                    else _default_guard(folded)
+                    or _date_function_guard(
+                        folded, _date_columns(conn, r["owner"], r["table_name"])
+                    )
+                )
                 if folded is None or guard is not None:
                     skip_reason = guard or (
                         "index expression could not be translated;"

--- a/src/pgrecon/convert/indexes.py
+++ b/src/pgrecon/convert/indexes.py
@@ -150,8 +150,10 @@ def _emit_indexes(
                 (k["column_name"] or "").upper()
                 for k in conn.execute(
                     "SELECT column_name FROM part_key_columns"
+                    " WHERE owner = ? AND table_name = ?"
+                    " UNION ALL SELECT column_name FROM part_subkey_columns"
                     " WHERE owner = ? AND table_name = ?",
-                    (r["owner"], r["table_name"]),
+                    (r["owner"], r["table_name"], r["owner"], r["table_name"]),
                 )
             ]
             uncovered = [k for k in part_keys if k not in plain]

--- a/src/pgrecon/convert/indexes.py
+++ b/src/pgrecon/convert/indexes.py
@@ -6,12 +6,14 @@ from pgrecon.convert.identifiers import (
     _date_function_guard,
     _default_guard,
     _fold_expression,
+    _type_mismatch_guard,
     ident,
     over_limit,
 )
 from pgrecon.convert.namespace import NameRegistry
 from pgrecon.convert.residue import Residue
-from pgrecon.convert.tables import _date_columns
+from pgrecon.convert.tables import _column_families, _date_columns
+from pgrecon.convert.typemap import UNINDEXABLE
 
 
 def _emit_indexes(
@@ -82,7 +84,9 @@ def _emit_indexes(
             )
         }
         parts: list[str] = []
+        plain: list[str] = []
         skip_reason: str | None = None
+        families = _column_families(conn, r["owner"], r["table_name"])
         for c in cols:
             expression, truncated = exprs.get(c["position"], (None, 0))
             if expression:
@@ -100,6 +104,7 @@ def _emit_indexes(
                     or _date_function_guard(
                         folded, _date_columns(conn, r["owner"], r["table_name"])
                     )
+                    or _type_mismatch_guard(folded, families)
                 )
                 if folded is None or guard is not None:
                     skip_reason = guard or (
@@ -119,8 +124,34 @@ def _emit_indexes(
             }:
                 skip_reason = f"column {c['column_name']} was not converted"
                 break
+            elif families.get((c["column_name"] or "").upper()) in UNINDEXABLE:
+                skip_reason = (
+                    f"column {c['column_name']} lands as"
+                    f" {families[(c['column_name'] or '').upper()]}, which has no"
+                    " btree operator class; index an expression over it by hand"
+                )
+                break
             else:
                 parts.append(ident(c["column_name"]))
+                plain.append((c["column_name"] or "").upper())
+        if skip_reason is None and (r["uniqueness"] or "").upper() == "UNIQUE":
+            # A unique index on a partitioned table must carry every
+            # partition key column, as a plain column.
+            part_keys = [
+                (k["column_name"] or "").upper()
+                for k in conn.execute(
+                    "SELECT column_name FROM part_key_columns"
+                    " WHERE owner = ? AND table_name = ?",
+                    (r["owner"], r["table_name"]),
+                )
+            ]
+            uncovered = [k for k in part_keys if k not in plain]
+            if uncovered:
+                skip_reason = (
+                    "PostgreSQL requires a unique index on a partitioned table"
+                    f" to include every partition key; {uncovered[0]} is"
+                    " missing - widen the index or enforce uniqueness another way"
+                )
         if skip_reason is not None or not parts:
             residue.append(
                 Residue(

--- a/src/pgrecon/convert/indexes.py
+++ b/src/pgrecon/convert/indexes.py
@@ -6,6 +6,7 @@ from pgrecon.convert.identifiers import (
     _date_function_guard,
     _default_guard,
     _fold_expression,
+    _referenced_columns,
     _type_mismatch_guard,
     ident,
     over_limit,
@@ -110,6 +111,14 @@ def _emit_indexes(
                     skip_reason = guard or (
                         "index expression could not be translated;"
                         " recreate it from the source"
+                    )
+                    break
+                present = {k.upper() for k in emitted[(r["owner"], r["table_name"])]}
+                unknown = sorted((_referenced_columns(folded) or set()) - present)
+                if unknown:
+                    skip_reason = (
+                        f"index expression references {unknown[0]}, which is not"
+                        " a column of the converted table"
                     )
                     break
                 parts.append(f"({folded})")

--- a/src/pgrecon/convert/mviews.py
+++ b/src/pgrecon/convert/mviews.py
@@ -107,6 +107,35 @@ def _emit_mviews(
                 )
             )
             continue
+        # The container's column list names the query's outputs one for
+        # one; a query that yields a different number, or names two
+        # outputs alike, cannot be mounted under that list.
+        outputs = list(tree.expressions)
+        if not any(isinstance(e, exp.Star) for e in outputs):
+            if len(outputs) != len(columns):
+                residue.append(
+                    Residue(
+                        owner,
+                        raw,
+                        "materialized view",
+                        f"the defining query yields {len(outputs)} columns but"
+                        f" the container has {len(columns)}; recreate the view"
+                        " by hand",
+                    )
+                )
+                continue
+            aliases = [(e.alias_or_name or "").upper() for e in outputs]
+            if len(set(aliases)) != len(aliases):
+                residue.append(
+                    Residue(
+                        owner,
+                        raw,
+                        "materialized view",
+                        "the defining query names two output columns alike;"
+                        " recreate the view with distinct aliases",
+                    )
+                )
+                continue
         guard = _view_guard(tree, name, emitted, dropped, created_views)
         if guard is not None:
             residue.append(Residue(owner, raw, "materialized view", guard))

--- a/src/pgrecon/convert/mviews.py
+++ b/src/pgrecon/convert/mviews.py
@@ -17,7 +17,7 @@ from sqlglot.transforms import eliminate_join_marks
 from pgrecon.convert.identifiers import _fold_identifiers, ident
 from pgrecon.convert.namespace import NameRegistry
 from pgrecon.convert.residue import Residue
-from pgrecon.convert.views import _view_guard
+from pgrecon.convert.views import _fold_rownum, _view_guard
 from pgrecon.inventory.loader import PARSE_NORMALIZATIONS
 
 
@@ -81,6 +81,10 @@ def _emit_mviews(
             tree = parsed[0] if parsed else None
             if tree is None:
                 raise SqlglotError("query did not parse")
+            rownum_reason = _fold_rownum(tree)
+            if rownum_reason is not None:
+                residue.append(Residue(owner, raw, "materialized view", rownum_reason))
+                continue
             tree = eliminate_join_marks(tree)
             tree = _fold_identifiers(tree)
             statement = tree.sql(

--- a/src/pgrecon/convert/mviews.py
+++ b/src/pgrecon/convert/mviews.py
@@ -54,18 +54,22 @@ def _emit_mviews(
 
     count = 0
     for (owner, name), r in sorted(queries.items()):
-        columns = [
-            (c["column_name"] or "").upper()
+        # Lookups and output use the catalog spelling; the uppercased
+        # key only orders and cross-references.
+        raw = r["mview_name"] or name
+        raw_columns = [
+            c["column_name"] or ""
             for c in conn.execute(
                 "SELECT column_name FROM columns"
                 " WHERE owner = ? AND table_name = ? ORDER BY position",
-                (owner, name),
+                (r["owner"] or owner, raw),
             )
         ]
+        columns = [c.upper() for c in raw_columns]
         if not columns:
             residue.append(
                 Residue(
-                    owner, name, "materialized view", "no column facts in the inventory"
+                    owner, raw, "materialized view", "no column facts in the inventory"
                 )
             )
             continue
@@ -87,7 +91,7 @@ def _emit_mviews(
             residue.append(
                 Residue(
                     owner,
-                    name,
+                    raw,
                     "materialized view",
                     f"defining query needs a manual rewrite: {reason}",
                 )
@@ -97,7 +101,7 @@ def _emit_mviews(
             residue.append(
                 Residue(
                     owner,
-                    name,
+                    raw,
                     "materialized view",
                     "defining query is not a plain SELECT; rewrite by hand",
                 )
@@ -105,18 +109,15 @@ def _emit_mviews(
             continue
         guard = _view_guard(tree, name, emitted, dropped, created_views)
         if guard is not None:
-            residue.append(Residue(owner, name, "materialized view", guard))
+            residue.append(Residue(owner, raw, "materialized view", guard))
             continue
-        if not names.claim(name, "materialized view", owner, residue):
+        if not names.claim(raw, "materialized view", owner, residue):
             continue
         # The container's column names come first: Oracle derived them
         # from the query once, and indexes converted from the container
         # reference them by exactly these names.
-        header = ", ".join(ident(c.lower()) for c in columns)
-        out.append(
-            f"CREATE MATERIALIZED VIEW {ident(name.lower())} ({header}) AS\n"
-            f"{statement};"
-        )
+        header = ", ".join(ident(c) for c in raw_columns)
+        out.append(f"CREATE MATERIALIZED VIEW {ident(raw)} ({header}) AS\n{statement};")
         out.append("")
         emitted[(owner, name)] = set(columns)
         created_views.add(name)
@@ -125,7 +126,7 @@ def _emit_mviews(
         residue.append(
             Residue(
                 owner,
-                name,
+                raw,
                 "note",
                 f"Oracle refreshed this materialized view ({refresh});"
                 " PostgreSQL refreshes on command - schedule REFRESH"
@@ -136,7 +137,7 @@ def _emit_mviews(
             residue.append(
                 Residue(
                     owner,
-                    name,
+                    raw,
                     "note",
                     "query rewrite does not exist in PostgreSQL - point"
                     " queries at the materialized view directly",

--- a/src/pgrecon/convert/namespace.py
+++ b/src/pgrecon/convert/namespace.py
@@ -18,7 +18,7 @@ constraints and triggers are per table (pg_constraint, pg_trigger);
 scopes keep those apart.
 """
 
-from pgrecon.convert.identifiers import over_limit, pg_truncate
+from pgrecon.convert.identifiers import fold_case, over_limit, pg_truncate
 from pgrecon.convert.residue import Residue
 
 RELATIONS = ""
@@ -33,7 +33,7 @@ class NameRegistry:
 
     def peek(self, name: str, scope: str = RELATIONS) -> tuple[str, str] | None:
         """The (name, kind) already holding this name, if any."""
-        return self._claimed.get((scope, pg_truncate((name or "").lower())))
+        return self._claimed.get((scope, pg_truncate(fold_case(name or ""))))
 
     def claim(
         self,
@@ -50,11 +50,11 @@ class NameRegistry:
         truncation note, because PostgreSQL will shorten it the same
         way everywhere it is referenced.
         """
-        key = (scope, pg_truncate((name or "").lower()))
+        key = (scope, pg_truncate(fold_case(name or "")))
         prior = self._claimed.get(key)
         if prior is not None:
             prior_name, prior_kind = prior
-            if (name or "").lower() == (prior_name or "").lower():
+            if fold_case(name or "") == fold_case(prior_name or ""):
                 reason = (
                     f"name collides with {prior_kind} {prior_name}: Oracle"
                     " keeps them in separate namespaces, PostgreSQL does"

--- a/src/pgrecon/convert/partitions.py
+++ b/src/pgrecon/convert/partitions.py
@@ -37,6 +37,24 @@ def _bound_to_pg(value: str | None) -> str | None:
     return v
 
 
+def _key_count(
+    conn: sqlite3.Connection, owner: str, table: str, fact_table: str
+) -> int:
+    row = conn.execute(
+        f"SELECT COUNT(*) FROM {fact_table} WHERE owner = ? AND table_name = ?",
+        (owner, table),
+    ).fetchone()
+    return max(int(row[0]) if row else 1, 1)
+
+
+def _widen_maxvalue(high_value: str | None, key_count: int) -> str | None:
+    """Oracle spells a multi-column open upper bound per column; a bare
+    MAXVALUE against several key columns needs one per column."""
+    if high_value and high_value.strip().upper() == "MAXVALUE" and key_count > 1:
+        return ", ".join(["MAXVALUE"] * key_count)
+    return high_value
+
+
 def _part_keys(
     conn: sqlite3.Connection, owner: str, table: str, fact_table: str
 ) -> str:
@@ -136,7 +154,9 @@ def _emit_partition_children(
         return 0
 
     statements: list[str] = []
-    prev = "MINVALUE"
+    # A range floor names one value per key column.
+    key_count = _key_count(conn, owner, table, "part_key_columns")
+    prev = ", ".join(["MINVALUE"] * key_count)
     for p in parts:
         child = f"{table}_{p['partition_name']}"
         if len(child) > 63:
@@ -166,7 +186,7 @@ def _emit_partition_children(
         names.claim(child, "partition child", owner, residue)
         spec, prev = _child_spec(
             meta.ptype,
-            p["high_value"],
+            _widen_maxvalue(p["high_value"], key_count),
             p["truncated"],
             p["position"] or 1,
             len(parts),
@@ -206,7 +226,8 @@ def _emit_partition_children(
                     )
                 )
                 return 0
-            sub_prev = "MINVALUE"
+            sub_keys = _key_count(conn, owner, table, "part_subkey_columns")
+            sub_prev = ", ".join(["MINVALUE"] * sub_keys)
             for s in subs:
                 sub_child = f"{table}_{p['partition_name']}_{s['subpartition_name']}"
                 if len(sub_child) > 63:
@@ -237,7 +258,7 @@ def _emit_partition_children(
                 names.claim(sub_child, "partition child", owner, residue)
                 sub_spec, sub_prev = _child_spec(
                     meta.subtype,
-                    s["high_value"],
+                    _widen_maxvalue(s["high_value"], sub_keys),
                     s["truncated"],
                     s["position"] or 1,
                     len(subs),

--- a/src/pgrecon/convert/plsql_rewrite.py
+++ b/src/pgrecon/convert/plsql_rewrite.py
@@ -79,6 +79,9 @@ class _Rewriter(PlSqlParserListener):  # type: ignore[misc]
         self.relations = relations
         self.procedures = procedures
         self.edits: list[tuple[int, int, str]] = []
+        # Loop variables of cursor FOR loops, which Oracle declares by
+        # itself and PL/pgSQL wants declared as records.
+        self.records: list[str] = []
         self.reasons: list[str] = []
         self.notes: list[str] = []
         self.suppressed: list[tuple[int, int]] = []
@@ -198,6 +201,13 @@ class _Rewriter(PlSqlParserListener):  # type: ignore[misc]
                 ctx,
                 "cursor parameter defaults are not supported; pass the value at OPEN",
             )
+
+    def enterCursor_loop_param(self, ctx: Any) -> None:
+        record = ctx.record_name()
+        if record is not None:
+            name = _fold_written(self._span_text(record))
+            if name not in self.records:
+                self.records.append(name)
 
     # -- declarations -----------------------------------------------
 
@@ -746,7 +756,8 @@ def rewrite_unit(
     while delimiter in edited:
         delimiter = delimiter[:-1] + "_$"
     opener = f"LANGUAGE plpgsql\nAS {delimiter}\n"
-    if rewriter.declares:
-        opener += "DECLARE"
+    records = "".join(f"\n  {name} record;" for name in rewriter.records)
+    if rewriter.declares or records:
+        opener += "DECLARE" + records
     edited = edited.replace(_BODY_OPEN, opener, 1)
     return RewriteResult(edited.rstrip() + f"\n{delimiter};", (), notes)

--- a/src/pgrecon/convert/schema.py
+++ b/src/pgrecon/convert/schema.py
@@ -97,11 +97,14 @@ def _convert(conn: sqlite3.Connection) -> Conversion:
     )
     mview_count = _emit_mviews(conn, out, residue, emitted, dropped, set(), names)
 
-    constraint_count += _emit_keys(conn, out, residue, emitted, names, mv_names)
+    key_count, emitted_keys = _emit_keys(conn, out, residue, emitted, names, mv_names)
+    constraint_count += key_count
     constraint_count += _emit_checks(
         conn, out, residue, emitted, dropped, names, mv_names
     )
-    constraint_count += _emit_foreign_keys(conn, out, residue, emitted, names, mv_names)
+    constraint_count += _emit_foreign_keys(
+        conn, out, residue, emitted, names, mv_names, emitted_keys
+    )
     index_count = _emit_indexes(conn, out, residue, emitted, names)
     view_count, created_views = _emit_views(conn, out, residue, emitted, dropped, names)
     synonym_count, synonym_names = _emit_synonyms(

--- a/src/pgrecon/convert/schema.py
+++ b/src/pgrecon/convert/schema.py
@@ -124,7 +124,7 @@ def _convert(conn: sqlite3.Connection) -> Conversion:
         emitted,
         mv_names,
         sequence_names,
-        {t for (_, t) in emitted} | created_views | synonym_names,
+        {t.upper() for (_, t) in emitted} | created_views | synonym_names,
         frozenset(
             (r["name"] or "").upper()
             for r in conn.execute("SELECT name FROM objects WHERE type = 'PROCEDURE'")

--- a/src/pgrecon/convert/schema.py
+++ b/src/pgrecon/convert/schema.py
@@ -93,7 +93,7 @@ def _convert(conn: sqlite3.Connection) -> Conversion:
     # tables; constraints and triggers must decline them by name.
     mv_names = {name for (_, name) in mview_queries(conn)}
     table_count, partition_count = emit_tables(
-        conn, out, residue, emitted, dropped, names, mv_names
+        conn, out, residue, emitted, dropped, names, mv_names, sequence_names
     )
     mview_count = _emit_mviews(conn, out, residue, emitted, dropped, set(), names)
 

--- a/src/pgrecon/convert/tables.py
+++ b/src/pgrecon/convert/tables.py
@@ -5,6 +5,7 @@ import sqlite3
 
 from pgrecon.convert.identifiers import (
     _date_function_guard,
+    _default_column_guard,
     _default_guard,
     _fold_expression,
     ident,
@@ -28,6 +29,30 @@ _SEQUENCE_DEFAULT = re.compile(
 )
 # LOB initializers: an empty, non-null value of the target type.
 _EMPTY_LOBS = {"EMPTY_CLOB()": "''", "EMPTY_BLOB()": "''::bytea"}
+
+
+_STRING_LITERAL = re.compile(r"^'((?:[^']|'')*)'$")
+
+
+def _literal_length_guard(folded: str, column: sqlite3.Row) -> str | None:
+    """A string default longer than its column: Oracle accepts the
+    table and rejects the row; PostgreSQL rejects the table."""
+    m = _STRING_LITERAL.match(folded.strip())
+    if m is None:
+        return None
+    dtype = (column["data_type"] or "").upper()
+    length = column["data_length"]
+    if dtype not in ("VARCHAR2", "NVARCHAR2", "CHAR", "NCHAR") or not length:
+        return None
+    chars = len(m.group(1).replace("''", "'"))
+    if dtype.startswith("N"):
+        length = length // 2
+    if chars > length:
+        return (
+            f"default literal is {chars} characters, longer than the column;"
+            " Oracle would reject the row, PostgreSQL rejects the table"
+        )
+    return None
 
 
 def _date_columns(conn: sqlite3.Connection, owner: str, table: str) -> set[str]:
@@ -277,6 +302,8 @@ def emit_tables(
                         if folded is None
                         else _default_guard(folded)
                         or _date_function_guard(folded, date_cols)
+                        or _default_column_guard(folded)
+                        or _literal_length_guard(folded, c)
                     )
                     if folded is None or guard is not None:
                         residue.append(

--- a/src/pgrecon/convert/tables.py
+++ b/src/pgrecon/convert/tables.py
@@ -9,6 +9,7 @@ from pgrecon.convert.identifiers import (
     _default_guard,
     _fold_expression,
     _referenced_columns,
+    _type_mismatch_guard,
     ident,
     over_limit,
     truncation_clash,
@@ -16,7 +17,7 @@ from pgrecon.convert.identifiers import (
 from pgrecon.convert.namespace import NameRegistry
 from pgrecon.convert.partitions import _emit_partition_children, _partition_meta
 from pgrecon.convert.residue import Residue
-from pgrecon.convert.typemap import map_type
+from pgrecon.convert.typemap import expression_family, map_type
 
 # Oracle identity columns store their backing sequence as the column
 # default; the name is always ISEQ$$_<object id>.
@@ -54,6 +55,25 @@ def _literal_length_guard(folded: str, column: sqlite3.Row) -> str | None:
             " Oracle would reject the row, PostgreSQL rejects the table"
         )
     return None
+
+
+def _column_families(
+    conn: sqlite3.Connection, owner: str, table: str
+) -> dict[str, str]:
+    """Upper-cased column name to expression family, for the type-aware
+    expression guards."""
+    families: dict[str, str] = {}
+    for r in conn.execute(
+        "SELECT column_name, data_type, data_length, data_precision, data_scale"
+        " FROM columns WHERE owner = ? AND table_name = ?",
+        (owner, table),
+    ):
+        mapped = map_type(
+            r["data_type"], r["data_length"], r["data_precision"], r["data_scale"]
+        ).pg_type
+        if mapped is not None:
+            families[(r["column_name"] or "").upper()] = expression_family(mapped)
+    return families
 
 
 def _date_columns(conn: sqlite3.Connection, owner: str, table: str) -> set[str]:
@@ -177,6 +197,7 @@ def emit_tables(
             name for name, r in extras.items() if (r["virtual"] or "NO") == "YES"
         }
         date_cols = _date_columns(conn, owner, table)
+        families = _column_families(conn, owner, table)
         for c in cols:
             mapped = map_type(
                 c["data_type"], c["data_length"], c["data_precision"], c["data_scale"]
@@ -224,7 +245,9 @@ def emit_tables(
                 guard = (
                     None
                     if expr is None
-                    else _default_guard(expr) or _date_function_guard(expr, date_cols)
+                    else _default_guard(expr)
+                    or _date_function_guard(expr, date_cols)
+                    or _type_mismatch_guard(expr, families)
                 )
                 if expr is not None and guard is None:
                     # PostgreSQL generated columns cannot read one another.
@@ -317,6 +340,7 @@ def emit_tables(
                         if folded is None
                         else _default_guard(folded)
                         or _date_function_guard(folded, date_cols)
+                        or _type_mismatch_guard(folded, families)
                         or _default_column_guard(folded)
                         or _literal_length_guard(folded, c)
                     )

--- a/src/pgrecon/convert/tables.py
+++ b/src/pgrecon/convert/tables.py
@@ -4,6 +4,7 @@ import re
 import sqlite3
 
 from pgrecon.convert.identifiers import (
+    _date_function_guard,
     _default_guard,
     _fold_expression,
     ident,
@@ -18,6 +19,27 @@ from pgrecon.convert.typemap import map_type
 # Oracle identity columns store their backing sequence as the column
 # default; the name is always ISEQ$$_<object id>.
 _IDENTITY_DEFAULT = re.compile(r"ISEQ\$\$_\d+.{0,4}NEXTVAL", re.IGNORECASE | re.DOTALL)
+
+# A default drawing from a sequence, as the catalog spells it:
+# "OWNER"."SEQ"."NEXTVAL", SEQ.NEXTVAL, quoted or bare in any mix.
+_SEQUENCE_DEFAULT = re.compile(
+    r'^\s*(?:("[^"]+"|[\w$#]+)\s*\.\s*)?("[^"]+"|[\w$#]+)\s*\.\s*"?NEXTVAL"?\s*$',
+    re.IGNORECASE,
+)
+# LOB initializers: an empty, non-null value of the target type.
+_EMPTY_LOBS = {"EMPTY_CLOB()": "''", "EMPTY_BLOB()": "''::bytea"}
+
+
+def _date_columns(conn: sqlite3.Connection, owner: str, table: str) -> set[str]:
+    """Upper-cased names of the table's DATE and TIMESTAMP columns."""
+    return {
+        (r["column_name"] or "").upper()
+        for r in conn.execute(
+            "SELECT column_name FROM columns WHERE owner = ? AND table_name = ?"
+            " AND (UPPER(data_type) = 'DATE' OR UPPER(data_type) LIKE 'TIMESTAMP%')",
+            (owner, table),
+        )
+    }
 
 
 def _columns(conn: sqlite3.Connection, owner: str, table: str) -> list[sqlite3.Row]:
@@ -37,6 +59,7 @@ def emit_tables(
     dropped: dict[tuple[str, str], set[str]],
     names: NameRegistry,
     skip_mviews: set[str] | None = None,
+    sequence_names: set[str] | None = None,
 ) -> tuple[int, int]:
     """Emit every table; returns (table_count, partition_count).
 
@@ -123,6 +146,8 @@ def emit_tables(
         }
         lines: list[str] = []
         kept_columns: set[str] = set()
+        virtual_columns: set[str] = set()
+        date_cols = _date_columns(conn, owner, table)
         for c in cols:
             mapped = map_type(
                 c["data_type"], c["data_length"], c["data_precision"], c["data_scale"]
@@ -161,12 +186,17 @@ def emit_tables(
                 )
             extra = extras.get(cname)
             if extra is not None and (extra["virtual"] or "NO") == "YES":
+                virtual_columns.add(cname)
                 expr = (
                     None
                     if extra["truncated"]
                     else _fold_expression(extra["default_text"] or "")
                 )
-                guard = None if expr is None else _default_guard(expr)
+                guard = (
+                    None
+                    if expr is None
+                    else _default_guard(expr) or _date_function_guard(expr, date_cols)
+                )
                 if expr is None or guard is not None:
                     residue.append(
                         Residue(
@@ -208,9 +238,46 @@ def emit_tables(
                             " column emitted without it",
                         )
                     )
+                elif (
+                    seq := _SEQUENCE_DEFAULT.match(extra["default_text"])
+                ) is not None:
+                    # A default drawn from a sequence; PostgreSQL wants
+                    # nextval over the converted sequence, by its
+                    # catalog spelling, and only if it exists.
+                    wanted = seq.group(2).strip('"').upper()
+                    raw_seq = conn.execute(
+                        "SELECT sequence_name FROM sequences"
+                        " WHERE UPPER(sequence_name) = ? LIMIT 1",
+                        (wanted,),
+                    ).fetchone()
+                    if raw_seq is not None and wanted in (sequence_names or set()):
+                        suffix = (
+                            f" DEFAULT nextval('{ident(raw_seq['sequence_name'])}')"
+                        )
+                    else:
+                        residue.append(
+                            Residue(
+                                owner,
+                                f"{table}.{c['column_name']}",
+                                "note",
+                                f"default draws from sequence {wanted}, which is"
+                                " not in the converted set; column emitted"
+                                " without it",
+                            )
+                        )
+                elif extra["default_text"].replace(" ", "").upper() in _EMPTY_LOBS:
+                    suffix = (
+                        " DEFAULT "
+                        + _EMPTY_LOBS[extra["default_text"].replace(" ", "").upper()]
+                    )
                 else:
                     folded = _fold_expression(extra["default_text"])
-                    guard = None if folded is None else _default_guard(folded)
+                    guard = (
+                        None
+                        if folded is None
+                        else _default_guard(folded)
+                        or _date_function_guard(folded, date_cols)
+                    )
                     if folded is None or guard is not None:
                         residue.append(
                             Residue(
@@ -241,6 +308,27 @@ def emit_tables(
             )
             continue
         meta, part_reason = _partition_meta(conn, owner, table)
+        if meta is not None:
+            # PostgreSQL cannot partition by a generated column, nor by
+            # a column that did not convert.
+            gone = dropped.get((owner, table), set())
+            for k in conn.execute(
+                "SELECT column_name FROM part_key_columns"
+                " WHERE owner = ? AND table_name = ? ORDER BY position",
+                (owner, table),
+            ):
+                key = (k["column_name"] or "").upper()
+                if key in virtual_columns:
+                    part_reason = (
+                        f"partition key {key} is a virtual column; PostgreSQL"
+                        " cannot partition by a generated column - partition by"
+                        " the expression itself by hand"
+                    )
+                elif key in gone or key not in kept_columns:
+                    part_reason = f"partition key {key} was not converted"
+                if part_reason is not None:
+                    meta = None
+                    break
         if part_reason is not None:
             residue.append(Residue(owner, table, "partitioning", part_reason))
         if (t["temporary"] or "N") == "Y":

--- a/src/pgrecon/convert/tables.py
+++ b/src/pgrecon/convert/tables.py
@@ -8,6 +8,7 @@ from pgrecon.convert.identifiers import (
     _default_column_guard,
     _default_guard,
     _fold_expression,
+    _referenced_columns,
     ident,
     over_limit,
     truncation_clash,
@@ -172,6 +173,9 @@ def emit_tables(
         lines: list[str] = []
         kept_columns: set[str] = set()
         virtual_columns: set[str] = set()
+        all_virtual = {
+            name for name, r in extras.items() if (r["virtual"] or "NO") == "YES"
+        }
         date_cols = _date_columns(conn, owner, table)
         for c in cols:
             mapped = map_type(
@@ -222,6 +226,17 @@ def emit_tables(
                     if expr is None
                     else _default_guard(expr) or _date_function_guard(expr, date_cols)
                 )
+                if expr is not None and guard is None:
+                    # PostgreSQL generated columns cannot read one another.
+                    chained = sorted(
+                        (_referenced_columns(expr) or set()) & (all_virtual - {cname})
+                    )
+                    if chained:
+                        guard = (
+                            f"expression reads virtual column {chained[0]};"
+                            " PostgreSQL generated columns cannot reference one"
+                            " another - inline the expression by hand"
+                        )
                 if expr is None or guard is not None:
                     residue.append(
                         Residue(

--- a/src/pgrecon/convert/triggers.py
+++ b/src/pgrecon/convert/triggers.py
@@ -8,6 +8,7 @@ UPDATE OF column lists survive. Everything else - compound triggers,
 system triggers, INSTEAD OF, UPDATING('col') - refuses by name.
 """
 
+import re
 import sqlite3
 from typing import Any
 
@@ -17,7 +18,7 @@ from pgrecon.convert.code import (
     _feature_gate,
     _unit_text,
 )
-from pgrecon.convert.identifiers import _fold_condition
+from pgrecon.convert.identifiers import _fold_condition, fold_case, ident
 from pgrecon.convert.namespace import ROUTINES, NameRegistry
 from pgrecon.convert.plsql_rewrite import (
     _apply,
@@ -130,6 +131,20 @@ def _trigger_function(
     return sql, [], list(result.notes)
 
 
+def _function_name(trigger: str) -> str:
+    """A plain identifier for the trigger's function.
+
+    Derived from the trigger's name with everything PostgreSQL would
+    need quoted replaced, so the CREATE FUNCTION header and every
+    reference to it agree; the name registry catches the rare
+    collision two odd names could produce.
+    """
+    slug = re.sub(r"[^a-z0-9_]", "_", fold_case(trigger).lower())
+    if not re.match(r"[a-z_]", slug[:1]):
+        slug = "t_" + slug
+    return f"{slug}_fn"
+
+
 def _emit_triggers(
     conn: sqlite3.Connection,
     out: list[str],
@@ -149,7 +164,8 @@ def _emit_triggers(
         "SELECT owner, trigger_name, trigger_type, table_name, status FROM triggers"
         " ORDER BY owner, trigger_name"
     ).fetchall()
-    tables = {t for (_, t) in emitted}
+    tables = {t.upper() for (_, t) in emitted}
+    by_upper = {t.upper(): t for (_, t) in emitted}
     for r in rows:
         owner, name = r["owner"], r["trigger_name"]
         kind = (r["trigger_type"] or "").upper()
@@ -263,17 +279,19 @@ def _emit_triggers(
                 Residue(owner, name, "trigger", "the trigger header did not dissect")
             )
             continue
-        table = _fold_written(_span(text, table_ctx)).lower()
-        if table.upper() not in tables:
+        written = _fold_written(_span(text, table_ctx)).strip('"')
+        raw_table = by_upper.get(written.upper())
+        if raw_table is None:
             residue.append(
                 Residue(
                     owner,
                     name,
                     "trigger",
-                    f"its table {table.upper()} is not in the converted set",
+                    f"its table {written.upper()} is not in the converted set",
                 )
             )
             continue
+        table = ident(raw_table)
         events = " OR ".join(
             " ".join(_span(text, e).lower().split())
             for e in _walk_all(event_clause, "Dml_event_element")
@@ -319,7 +337,7 @@ def _emit_triggers(
             else:
                 when_sql = f" WHEN ({folded})"
 
-        fn_name = f"{name.lower()}_fn"
+        fn_name = _function_name(name)
         fn_sql, fn_reasons, fn_notes = _trigger_function(
             text,
             parse.tree,
@@ -345,22 +363,36 @@ def _emit_triggers(
         # name in its table's trigger namespace; a collision on the
         # function would let CREATE OR REPLACE silently replace an
         # earlier one.
-        if not names.claim(fn_name, "trigger function", owner, residue, scope=ROUTINES):
+        holder = names.peek(fn_name, scope=ROUTINES)
+        if holder is not None:
+            # The refusal names the trigger, which is what the reader
+            # knows; the function name is the converter's own.
+            residue.append(
+                Residue(
+                    owner,
+                    name,
+                    "trigger",
+                    f"its function {fn_name} would collide with {holder[1]}"
+                    f" {holder[0]} within PostgreSQL's 63-byte identifier"
+                    " limit; rename the trigger",
+                )
+            )
             continue
+        names.claim(fn_name, "trigger function", owner, residue, scope=ROUTINES)
         if not names.claim(
-            name, "trigger", owner, residue, scope=f"trigger:{table.upper()}"
+            name, "trigger", owner, residue, scope=f"trigger:{raw_table.upper()}"
         ):
             continue
         out.append(fn_sql)
         out.append("")
         level = "FOR EACH ROW" if row_level else "FOR EACH STATEMENT"
         out.append(
-            f"CREATE TRIGGER {name.lower()} {timing} {events} ON {table}\n"
+            f"CREATE TRIGGER {ident(name)} {timing} {events} ON {table}\n"
             f"{level}{when_sql}\n"
             f"EXECUTE FUNCTION {fn_name}();"
         )
         if (r["status"] or "").upper() == "DISABLED":
-            out.append(f"ALTER TABLE {table} DISABLE TRIGGER {name.lower()};")
+            out.append(f"ALTER TABLE {table} DISABLE TRIGGER {ident(name)};")
         out.append("")
         for note in fn_notes:
             residue.append(Residue(owner, name, "note", note))

--- a/src/pgrecon/convert/typemap.py
+++ b/src/pgrecon/convert/typemap.py
@@ -200,3 +200,25 @@ def fk_compatible(child: str, parent: str) -> bool:
         ("integer", "float"),
         ("numeric", "float"),
     }
+
+
+# Types with no default btree operator class: neither an index nor a
+# unique key can be built on them without an expression.
+UNINDEXABLE = {"xml", "json"}
+
+
+def indexable(pg_type: str) -> bool:
+    return pg_type.split("(")[0].strip().lower() not in UNINDEXABLE
+
+
+def expression_family(pg_type: str) -> str:
+    """The coarse family an expression checker reasons in: text, number,
+    datetime, binary, or the bare type name."""
+    family = _type_family(pg_type)
+    if family in ("integer", "numeric", "float"):
+        return "number"
+    if family in ("text", "char"):
+        return "text"
+    if family == "bytea":
+        return "binary"
+    return family

--- a/src/pgrecon/convert/typemap.py
+++ b/src/pgrecon/convert/typemap.py
@@ -162,3 +162,41 @@ def map_code_type(text: str) -> Mapped:
         # honest mapping is numeric, not a range-limited integer.
         return Mapped("numeric")
     return map_type(base, length, precision, scale)
+
+
+def _type_family(pg_type: str) -> str:
+    base = pg_type.split("(")[0].strip().lower()
+    if base in ("smallint", "integer", "bigint"):
+        return "integer"
+    if base in ("numeric", "decimal"):
+        return "numeric"
+    if base in ("real", "double precision"):
+        return "float"
+    if base in ("varchar", "text", "character varying"):
+        return "text"
+    if base in ("char", "character", "bpchar"):
+        return "char"
+    if base in ("date", "timestamp", "timestamptz"):
+        return "datetime"
+    return base
+
+
+def fk_compatible(child: str, parent: str) -> bool:
+    """Whether a foreign key from the child type to the parent type can
+    exist on PostgreSQL.
+
+    The referencing column must compare through the referenced key's
+    operator class, with implicit casts allowed: integers widen to
+    numeric or float, numeric to float, and the date and time types
+    share one class. Oracle lets VARCHAR2 reference CHAR and NUMBER
+    reference NUMBER(10); PostgreSQL does neither once the types have
+    landed on text against char, or numeric against bigint.
+    """
+    c, p = _type_family(child), _type_family(parent)
+    if c == p:
+        return True
+    return (c, p) in {
+        ("integer", "numeric"),
+        ("integer", "float"),
+        ("numeric", "float"),
+    }

--- a/src/pgrecon/convert/views.py
+++ b/src/pgrecon/convert/views.py
@@ -24,6 +24,53 @@ _OBJECT_VIEW = re.compile(r"\bVIEW\s+\"?[^\s(]+\s+OF\s", re.IGNORECASE)
 _JSON_TABLE = re.compile(r"\bJSON_TABLE\s*\(", re.IGNORECASE)
 
 
+def _fold_rownum(tree: Expr) -> str | None:
+    """Turn the top-N idiom into LIMIT, or say why the query cannot be.
+
+    Oracle numbers rows before ORDER BY, so the faithful shape is a
+    ROWNUM predicate over a sorted subquery; that predicate, as a
+    conjunct of its query's WHERE with a literal bound, becomes LIMIT
+    on that query. ROWNUM anywhere else - projected, compared with a
+    column, under OR, or beside an ORDER BY in the same query - has
+    no mechanical equal and declines by name.
+    """
+    rownums = [c for c in list(tree.find_all(exp.Column)) if c.name.upper() == "ROWNUM"]
+    for column in rownums:
+        comparison = column.parent
+        if not isinstance(comparison, exp.LTE | exp.LT | exp.EQ):
+            return "uses ROWNUM outside a top-N bound; rewrite by hand"
+        other = comparison.expression if comparison.this is column else comparison.this
+        if not (isinstance(other, exp.Literal) and not other.is_string):
+            return "compares ROWNUM with something other than a number; rewrite by hand"
+        bound = int(float(other.this))
+        if isinstance(comparison, exp.LT):
+            bound -= 1
+        elif isinstance(comparison, exp.EQ) and bound != 1:
+            return "ROWNUM = n with n above 1 never matches; rewrite by hand"
+        node: Expr = comparison
+        while isinstance(node.parent, exp.And):
+            node = node.parent
+        where = node.parent
+        if not isinstance(where, exp.Where) or not isinstance(where.parent, exp.Select):
+            return "uses ROWNUM outside a plain WHERE conjunction; rewrite by hand"
+        select = where.parent
+        if select.args.get("order") is not None:
+            return (
+                "ROWNUM beside ORDER BY in the same query is not top-N on"
+                " Oracle either; sort in a subquery, then bound, by hand"
+            )
+        if select.args.get("limit") is not None:
+            return "uses ROWNUM twice; rewrite by hand"
+        parent = comparison.parent
+        if isinstance(parent, exp.And):
+            sibling = parent.expression if parent.this is comparison else parent.this
+            parent.replace(sibling)
+        else:
+            select.set("where", None)
+        select.limit(bound, copy=False)
+    return None
+
+
 def _view_guard(
     tree: Expr,
     view_name: str,
@@ -306,6 +353,10 @@ def _emit_views(
             tree = parsed[0] if parsed else None
             if tree is None:
                 raise SqlglotError("statement did not parse")
+            rownum_reason = _fold_rownum(tree)
+            if rownum_reason is not None:
+                residue.append(Residue(r["owner"], name, "view", rownum_reason))
+                continue
             # The generator passes some Oracle-only constructs through
             # verbatim instead of flagging them; wrong DDL must become
             # residue, never output, so the tree is checked explicitly.

--- a/src/pgrecon/convert/views.py
+++ b/src/pgrecon/convert/views.py
@@ -8,7 +8,7 @@ from sqlglot import Expr, exp
 from sqlglot.errors import ErrorLevel, SqlglotError
 from sqlglot.transforms import eliminate_join_marks
 
-from pgrecon.convert.identifiers import _fold_identifiers, ident
+from pgrecon.convert.identifiers import _fold_identifiers, _trunc_unit_guard, ident
 from pgrecon.convert.namespace import NameRegistry
 from pgrecon.convert.residue import Residue
 from pgrecon.inventory.loader import PARSE_NORMALIZATIONS
@@ -32,6 +32,9 @@ def _view_guard(
     created_views: set[str],
 ) -> str | None:
     """Why a view cannot be emitted faithfully, or None."""
+    unit_guard = _trunc_unit_guard(tree)
+    if unit_guard is not None:
+        return unit_guard
     referenced: list[str] = []
     for node in tree.walk():
         if isinstance(node, exp.Table):

--- a/src/pgrecon/convert/views.py
+++ b/src/pgrecon/convert/views.py
@@ -45,7 +45,7 @@ def _view_guard(
             node.expression, exp.Func | exp.Anonymous | exp.Dot
         ):
             return "uses object-relational methods that have no counterpart"
-    known = {t for (_, t) in emitted} | created_views | {view_name.upper()}
+    known = {t.upper() for (_, t) in emitted} | created_views | {view_name.upper()}
     for tname in referenced:
         if tname not in known:
             return f"references {tname}, which is not in the converted set"
@@ -53,8 +53,8 @@ def _view_guard(
     if len(set(sources)) == 1:
         gone = set()
         for (_owner, t), cols in dropped.items():
-            if t == sources[0]:
-                gone |= cols
+            if t.upper() == sources[0]:
+                gone |= {c.upper() for c in cols}
         lost = sorted({c.name.upper() for c in tree.find_all(exp.Column)} & gone)
         if lost:
             return f"references {lost[0]}, a column that was not converted"
@@ -218,9 +218,24 @@ def _emit_views(
     rows = conn.execute(
         "SELECT owner, name, ddl FROM ddl WHERE type = 'VIEW' ORDER BY name"
     ).fetchall()
+    names = {r["name"] for r in rows}
+    # A view the catalog lists but whose DDL never reached the dump -
+    # DBMS_METADATA failed on it, or the spool was cut - is declined
+    # by name rather than forgotten.
+    for o in conn.execute(
+        "SELECT owner, name FROM objects WHERE type = 'VIEW' ORDER BY owner, name"
+    ):
+        if o["name"] not in names:
+            residue.append(
+                Residue(
+                    o["owner"],
+                    o["name"],
+                    "view",
+                    "no DDL for this view reached the dump; extract it by hand",
+                )
+            )
     if not rows:
         return 0, set()
-    names = {r["name"] for r in rows}
     edges: dict[str, set[str]] = {r["name"]: set() for r in rows}
     for d in conn.execute(
         "SELECT name, ref_name FROM dependencies"
@@ -315,7 +330,7 @@ def _emit_views(
                     continue
                 if not registry.claim(name, "view", r["owner"], residue):
                     continue
-                out.append(f"CREATE VIEW {ident(name.lower())} AS\n{built};")
+                out.append(f"CREATE VIEW {ident(name)} AS\n{built};")
                 out.append("")
                 created_views.add(name.upper())
                 wrote = True

--- a/src/pgrecon/convert/views.py
+++ b/src/pgrecon/convert/views.py
@@ -108,6 +108,23 @@ def _view_guard(
         lost = sorted({c.name.upper() for c in tree.find_all(exp.Column)} & gone)
         if lost:
             return f"references {lost[0]}, a column that was not converted"
+        # Over one table, every column named must be one the converted
+        # table has, or an alias the query itself defines; a spool cut
+        # short can leave a view naming a column that is not there.
+        present: set[str] | None = None
+        for (_owner, t), cols in emitted.items():
+            if t.upper() == sources[0]:
+                present = {c.upper() for c in cols}
+        aliases = {(e.alias or "").upper() for e in tree.find_all(exp.Alias) if e.alias}
+        if present is not None and tree.find(exp.Connect) is None:
+            unknown = sorted(
+                {c.name.upper() for c in tree.find_all(exp.Column)}
+                - present
+                - aliases
+                - {"ROWNUM", "LEVEL", "ROWID", "USER", "SYSDATE"}
+            )
+            if unknown:
+                return f"references {unknown[0]}, which is not a column of {sources[0]}"
     return None
 
 

--- a/src/pgrecon/inventory/loader.py
+++ b/src/pgrecon/inventory/loader.py
@@ -351,7 +351,9 @@ INT_COLUMNS = {
     "detected_usages",
 }
 
-DDL_MARKER = re.compile(r"^-- PGRECON_OBJECT (\S+) ([^\s.]+)\.(\S+)\s*$", re.MULTILINE)
+# The name runs to the end of the line: Oracle allows spaces and
+# commas inside a quoted identifier, and the spool writes it raw.
+DDL_MARKER = re.compile(r"^-- PGRECON_OBJECT (\S+) ([^\s.]+)\.(.+?)\s*$", re.MULTILINE)
 
 # DBMS_METADATA output carries physical and state keywords that
 # sqlglot's Oracle grammar rejects but that mean nothing for an

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1576,3 +1576,80 @@ def test_unique_index_on_partitioned_table_needs_the_key(parts_db: Path) -> None
     assert "part_uq_bad" not in result.sql
     reasons = {r.object_name: r.reason for r in result.residue}
     assert "every partition key; CODE is missing" in reasons["PART_UQ_BAD"]
+
+
+def test_rownum_top_n_becomes_limit_or_declines(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO ddl (owner, name, type, ddl, parse_ok, parse_quality) VALUES
+          ('HR', 'V_TOP', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_TOP" AS SELECT "EMP_ID" FROM'
+           || ' (SELECT "EMP_ID" FROM "HR"."EMP" ORDER BY "SALARY" DESC)'
+           || ' WHERE ROWNUM <= 5', 1, 'full'),
+          ('HR', 'V_FIRST', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_FIRST" AS SELECT "EMP_ID" FROM "HR"."EMP"'
+           || ' WHERE "SALARY" > 0 AND ROWNUM < 2', 1, 'full'),
+          ('HR', 'V_SORTED_ROWNUM', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_SORTED_ROWNUM" AS SELECT "EMP_ID"'
+           || ' FROM "HR"."EMP" WHERE ROWNUM <= 5 ORDER BY "SALARY"', 1, 'full'),
+          ('HR', 'V_ROWNUM_COL', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_ROWNUM_COL" AS SELECT ROWNUM AS RN,'
+           || ' "EMP_ID" FROM "HR"."EMP"', 1, 'full');
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    sql = result.sql
+    top = sql[sql.index("CREATE OR REPLACE VIEW v_top") :].split(";")[0]
+    assert "LIMIT 5" in top and "rownum" not in top.lower()
+    first = sql[sql.index("CREATE OR REPLACE VIEW v_first") :].split(";")[0]
+    assert "salary > 0" in first and "LIMIT 1" in first
+    assert "rownum" not in first.lower()
+    reasons = {r.object_name: r.reason for r in result.residue if r.kind == "view"}
+    assert "sort in a subquery" in reasons["V_SORTED_ROWNUM"]
+    assert "outside a top-N bound" in reasons["V_ROWNUM_COL"]
+
+
+def test_public_grant_option_is_dropped_with_a_note(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.execute(
+        "INSERT INTO grants (grantee, owner, table_name, privilege, grantable)"
+        " VALUES ('PUBLIC', 'HR', 'DEPT', 'SELECT', 'YES')"
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    assert "GRANT SELECT ON dept TO PUBLIC;" in result.sql
+    assert "TO PUBLIC WITH GRANT OPTION" not in result.sql
+    assert any("grant option to PUBLIC dropped" in r.reason for r in result.residue)
+
+
+def test_index_expression_over_unknown_column_declines(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO indexes (owner, index_name, table_name, index_type, uniqueness,
+                             generated)
+          VALUES ('HR', 'EMP_TORN_IX', 'EMP', 'FUNCTION-BASED NORMAL', 'NONUNIQUE',
+                  'N'),
+                 ('HR', 'EMP_TRUNC_TEXT_IX', 'EMP', 'FUNCTION-BASED NORMAL',
+                  'NONUNIQUE', 'N');
+        INSERT INTO index_columns (owner, index_name, column_name, position)
+          VALUES ('HR', 'EMP_TORN_IX', 'SYS_NC00012$', 1),
+                 ('HR', 'EMP_TRUNC_TEXT_IX', 'SYS_NC00013$', 1);
+        INSERT INTO index_expressions (owner, index_name, position, expression,
+                                       truncated)
+          VALUES ('HR', 'EMP_TORN_IX', 1, 'SYS_OP', 0),
+                 ('HR', 'EMP_TRUNC_TEXT_IX', 1, 'TRUNC("ENAME")', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    assert "emp_torn_ix" not in result.sql
+    assert "emp_trunc_text_ix" not in result.sql
+    reasons = {r.object_name: r.reason for r in result.residue}
+    assert "references SYS_OP, which is not a column" in reasons["EMP_TORN_IX"]
+    assert "TRUNC over text column ENAME" in reasons["EMP_TRUNC_TEXT_IX"]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1653,3 +1653,45 @@ def test_index_expression_over_unknown_column_declines(facts_db: Path) -> None:
     reasons = {r.object_name: r.reason for r in result.residue}
     assert "references SYS_OP, which is not a column" in reasons["EMP_TORN_IX"]
     assert "TRUNC over text column ENAME" in reasons["EMP_TRUNC_TEXT_IX"]
+
+
+def test_unique_key_on_composite_partition_needs_the_subkey(parts_db: Path) -> None:
+    conn = sqlite3.connect(parts_db)
+    conn.executescript(
+        """
+        INSERT INTO constraints (owner, constraint_name, table_name, type)
+          VALUES ('HR', 'LH_CODE_UK', 'LH', 'U'), ('HR', 'LH_BOTH_UK', 'LH', 'U');
+        INSERT INTO constraint_columns (owner, constraint_name, column_name, position)
+          VALUES ('HR', 'LH_CODE_UK', 'CODE', 1),
+                 ('HR', 'LH_BOTH_UK', 'CODE', 1), ('HR', 'LH_BOTH_UK', 'ID', 2);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(parts_db)
+    assert "ADD CONSTRAINT lh_both_uk UNIQUE (code, id);" in result.sql
+    assert "lh_code_uk" not in result.sql
+    reasons = {r.object_name: r.reason for r in result.residue}
+    assert "ID is missing" in reasons["LH_CODE_UK"]
+
+
+def test_view_over_a_column_the_table_lacks_declines(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO ddl (owner, name, type, ddl, parse_ok, parse_quality) VALUES
+          ('HR', 'V_TORN', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_TORN" AS SELECT "EMP_ID", "GHOST"'
+           || ' FROM "HR"."EMP" WHERE NOT "EMP_ID" IS NULL', 1, 'full'),
+          ('HR', 'V_ALIASED', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_ALIASED" AS SELECT "EMP_ID" AS ID,'
+           || ' "SALARY" * 2 AS DOUBLED FROM "HR"."EMP" ORDER BY DOUBLED', 1, 'full');
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    assert "v_torn" not in result.sql
+    assert "CREATE OR REPLACE VIEW v_aliased" in result.sql
+    reasons = {r.object_name: r.reason for r in result.residue if r.kind == "view"}
+    assert "GHOST, which is not a column of EMP" in reasons["V_TORN"]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import pytest
 
 from pgrecon.convert import convert_schema, residue_report
-from pgrecon.convert.identifiers import _fold_condition
+from pgrecon.convert.identifiers import (
+    _default_guard,
+    _fold_condition,
+    _fold_expression,
+)
 from pgrecon.convert.schema import ident
 from pgrecon.convert.typemap import map_type
 from pgrecon.inventory import open_db
@@ -261,7 +265,7 @@ def test_object_view_refuses(facts_db: Path) -> None:
 
 
 def test_expression_guards_sysop_and_systimestamp() -> None:
-    from pgrecon.convert.identifiers import _default_guard, _fold_expression
+    from pgrecon.convert.identifiers import _fold_expression
 
     guard = _default_guard("SYS_OP_MAP_NONNULL(dname)")
     assert guard is not None and "SYS_OP_MAP_NONNULL" in guard
@@ -1245,5 +1249,8 @@ def test_trunc_over_dates_declines_where_types_are_known(facts_db: Path) -> None
     assert "date column HIRED" in reasons["EMP_HIRED_CK"]
     assert "date column HIRED" in reasons["EMP_HIRED_DAY_IX"]
     assert "recreate it from the source" in reasons["EMP_HIRED_DESC_IX"]
-    hired_notes = [r.reason for r in result.residue if r.object_name == "EMP.HIRED"]
-    assert any("date expression" in note for note in hired_notes)
+    assert "hired timestamp(0) DEFAULT DATE_TRUNC('day', CURRENT_TIMESTAMP)" in sql
+    assert _fold_expression("TRUNC(SYSDATE, 'IW')") == (
+        "DATE_TRUNC('week', CURRENT_TIMESTAMP)"
+    )
+    assert _fold_expression("TRUNC(SYSDATE, 'W')") is None

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -86,6 +86,7 @@ def facts_db(tmp_path: Path) -> Path:
           ('HR', 'EMP',  'DEPT_ID',  2, 'NUMBER',   22, 4,  0, 'Y'),
           ('HR', 'EMP',  'HIRED',    3, 'DATE',     7,  NULL, NULL, 'Y'),
           ('HR', 'EMP',  'SALARY',   4, 'NUMBER',   22, 8,  2, 'Y'),
+          ('HR', 'EMP',  'ENAME',    5, 'VARCHAR2', 50, NULL, NULL, 'Y'),
           ('HR', 'SCANS', 'SCAN_ID', 1, 'NUMBER',   22, 10, 0, 'N'),
           ('HR', 'SCANS', 'DOC',     2, 'BFILE',    530, NULL, NULL, 'Y');
         INSERT INTO constraints
@@ -1333,3 +1334,164 @@ def test_defaults_that_postgres_cannot_evaluate_decline(facts_db: Path) -> None:
     notes = {r.object_name: r.reason for r in result.residue if r.kind == "note"}
     assert "longer than the column" in notes["DEPT.FLAG"]
     assert "UID, a column or Oracle pseudo-column" in notes["DEPT.OWNER_UID"]
+
+
+def test_foreign_key_to_a_key_that_did_not_convert_declines(tmp_path: Path) -> None:
+    """The parent's key is refused (a partitioned table whose key misses
+    the partition column), so the foreign key has nothing to point at."""
+    db = tmp_path / "inv.db"
+    conn = open_db(db)
+    conn.executescript(
+        """
+        INSERT INTO tables (owner, table_name, temporary) VALUES
+          ('HR', 'PARENT', 'N'), ('HR', 'CHILD', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'PARENT', 'ID',     1, 'NUMBER', 22, 10, 0, 'N'),
+          ('HR', 'PARENT', 'REGION', 2, 'NUMBER', 22, 3, 0, 'N'),
+          ('HR', 'CHILD',  'ID',     1, 'NUMBER', 22, 10, 0, 'N'),
+          ('HR', 'CHILD',  'P_ID',   2, 'NUMBER', 22, 10, 0, 'Y');
+        INSERT INTO constraints (owner, constraint_name, table_name, type, ref_owner,
+                                 ref_constraint, delete_rule) VALUES
+          ('HR', 'PARENT_PK', 'PARENT', 'P', NULL, NULL, NULL),
+          ('HR', 'CHILD_PK', 'CHILD', 'P', NULL, NULL, NULL),
+          ('HR', 'CHILD_FK', 'CHILD', 'R', 'HR', 'PARENT_PK', 'NO ACTION');
+        INSERT INTO constraint_columns (owner, constraint_name, column_name, position)
+          VALUES ('HR', 'PARENT_PK', 'ID', 1), ('HR', 'CHILD_PK', 'ID', 1),
+                 ('HR', 'CHILD_FK', 'P_ID', 1);
+        INSERT INTO part_tables (owner, table_name, partitioning_type,
+                                 subpartitioning_type, partition_count, interval)
+          VALUES ('HR', 'PARENT', 'HASH', 'NONE', 2, NULL);
+        INSERT INTO part_key_columns (owner, table_name, column_name, position)
+          VALUES ('HR', 'PARENT', 'REGION', 1);
+        INSERT INTO part_partitions (owner, table_name, partition_name, position,
+                                     high_value, truncated)
+          VALUES ('HR', 'PARENT', 'P1', 1, NULL, 0), ('HR', 'PARENT', 'P2', 2, NULL, 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(db)
+    assert "parent_pk" not in result.sql and "child_fk" not in result.sql
+    reasons = {r.object_name: r.reason for r in result.residue}
+    assert "every partition key" in reasons["PARENT_PK"]
+    assert "referenced key PARENT_PK was not converted" in reasons["CHILD_FK"]
+
+
+def test_index_and_check_over_missing_columns_decline(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO indexes (owner, index_name, table_name, index_type, uniqueness,
+                             generated)
+          VALUES ('HR', 'EMP_GHOST_IX', 'EMP', 'NORMAL', 'NONUNIQUE', 'N');
+        INSERT INTO index_columns (owner, index_name, column_name, position)
+          VALUES ('HR', 'EMP_GHOST_IX', 'EMP_ID', 1),
+                 ('HR', 'EMP_GHOST_IX', 'GHOST', 2);
+        INSERT INTO constraints (owner, constraint_name, table_name, type)
+          VALUES ('HR', 'EMP_GHOST_CK', 'EMP', 'C');
+        INSERT INTO check_conditions (owner, constraint_name, condition, truncated)
+          VALUES ('HR', 'EMP_GHOST_CK', '"GHOST" > 0', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    assert "emp_ghost_ix" not in result.sql and "emp_ghost_ck" not in result.sql
+    reasons = {r.object_name: r.reason for r in result.residue}
+    assert "column GHOST was not converted" in reasons["EMP_GHOST_IX"]
+    assert "GHOST, which is not a column" in reasons["EMP_GHOST_CK"]
+
+
+def test_multi_column_range_partitions_bound_every_column(tmp_path: Path) -> None:
+    db = tmp_path / "inv.db"
+    conn = open_db(db)
+    conn.executescript(
+        """
+        INSERT INTO tables (owner, table_name, temporary) VALUES ('HR', 'SALES', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'SALES', 'YEAR', 1, 'NUMBER', 22, 4, 0, 'N'),
+          ('HR', 'SALES', 'REGION', 2, 'VARCHAR2', 10, NULL, NULL, 'N');
+        INSERT INTO part_tables (owner, table_name, partitioning_type,
+                                 subpartitioning_type, partition_count, interval)
+          VALUES ('HR', 'SALES', 'RANGE', 'NONE', 2, NULL);
+        INSERT INTO part_key_columns (owner, table_name, column_name, position)
+          VALUES ('HR', 'SALES', 'YEAR', 1), ('HR', 'SALES', 'REGION', 2);
+        INSERT INTO part_partitions (owner, table_name, partition_name, position,
+                                     high_value, truncated)
+          VALUES ('HR', 'SALES', 'P_EARLY', 1,
+                  '2020, ' || char(39) || 'M' || char(39), 0),
+                 ('HR', 'SALES', 'P_REST', 2, 'MAXVALUE', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    sql = convert_schema(db).sql
+    assert "PARTITION BY RANGE (year, region)" in sql
+    assert "FOR VALUES FROM (MINVALUE, MINVALUE) TO (2020, 'M')" in sql
+    assert "FOR VALUES FROM (2020, 'M') TO (MAXVALUE, MAXVALUE)" in sql
+
+
+def test_virtual_column_over_virtual_column_declines(tmp_path: Path) -> None:
+    db = tmp_path / "inv.db"
+    conn = open_db(db)
+    conn.executescript(
+        """
+        INSERT INTO tables (owner, table_name, temporary) VALUES ('HR', 'PRICES', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'PRICES', 'NET',   1, 'NUMBER', 22, 12, 2, 'N'),
+          ('HR', 'PRICES', 'GROSS', 2, 'NUMBER', 22, 12, 2, 'Y'),
+          ('HR', 'PRICES', 'TWICE', 3, 'NUMBER', 22, 12, 2, 'Y');
+        INSERT INTO column_defaults (owner, table_name, column_name, default_text,
+                                     virtual, truncated) VALUES
+          ('HR', 'PRICES', 'GROSS', '"NET" * 1.2', 'YES', 0),
+          ('HR', 'PRICES', 'TWICE', '"GROSS" * 2', 'YES', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(db)
+    assert "gross numeric(12,2) GENERATED ALWAYS AS (net * 1.2) STORED" in result.sql
+    assert "twice" not in result.sql
+    reasons = {r.object_name: r.reason for r in result.residue}
+    assert "reads virtual column GROSS" in reasons["PRICES.TWICE"]
+
+
+def test_mview_whose_query_does_not_fit_its_container_declines(
+    facts_db: Path,
+) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO mviews (owner, mview_name, rewrite_enabled, refresh_method, query)
+          VALUES ('HR', 'MV_WIDE', 'N', 'COMPLETE',
+                  'SELECT "DEPT_ID", COUNT(*) AS N, SUM("SALARY") AS TOTAL'
+                  || ' FROM "HR"."EMP" GROUP BY "DEPT_ID"'),
+                 ('HR', 'MV_TWICE', 'N', 'COMPLETE',
+                  'SELECT "DEPT_ID", SUM("SALARY") AS DEPT_ID FROM "HR"."EMP"'
+                  || ' GROUP BY "DEPT_ID"');
+        INSERT INTO tables (owner, table_name, temporary)
+          VALUES ('HR', 'MV_WIDE', 'N'), ('HR', 'MV_TWICE', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'MV_WIDE', 'DEPT_ID', 1, 'NUMBER', 22, 4, 0, 'Y'),
+          ('HR', 'MV_WIDE', 'TOTAL',   2, 'NUMBER', 22, 8, 2, 'Y'),
+          ('HR', 'MV_TWICE', 'DEPT_ID', 1, 'NUMBER', 22, 4, 0, 'Y'),
+          ('HR', 'MV_TWICE', 'DEPT_ID_1', 2, 'NUMBER', 22, 8, 2, 'Y');
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    assert "mv_wide" not in result.sql and "mv_twice" not in result.sql
+    reasons = {
+        r.object_name: r.reason for r in result.residue if r.kind == "materialized view"
+    }
+    assert "yields 3 columns but the container has 2" in reasons["MV_WIDE"]
+    assert "two output columns alike" in reasons["MV_TWICE"]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,3 +1,5 @@
+import re
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -51,9 +53,16 @@ def test_unmappable_types_return_none_with_reason(oracle: str) -> None:
 
 def test_identifiers_fold_or_quote() -> None:
     assert ident("EMPLOYEES") == "employees"
-    assert ident("ORDER") == '"ORDER"'
-    assert ident("Weird Name") == '"Weird Name"'
     assert ident("T_1") == "t_1"
+    # Reserved words fold like any other case-insensitive name and
+    # then need quotes.
+    assert ident("ORDER") == '"order"'
+    assert ident("LIMIT") == '"limit"'
+    # A name with lowercase letters was created quoted on Oracle and
+    # keeps its spelling; spaces need quotes either way.
+    assert ident("Weird Name") == '"Weird Name"'
+    assert ident("MixedCase") == '"MixedCase"'
+    assert ident("WITH SPACE") == '"with space"'
 
 
 @pytest.fixture()
@@ -1038,3 +1047,87 @@ def test_registry_scopes_are_independent() -> None:
     assert registry.claim("CK", "check", "APP", residue, scope="constraint:T1")
     assert registry.claim("CK", "check", "APP", residue, scope="constraint:T2")
     assert not registry.claim("CK", "check", "APP", residue, scope="constraint:T1")
+
+
+def test_check_without_condition_is_declined_by_name(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.execute(
+        "INSERT INTO constraints (owner, constraint_name, table_name, type)"
+        " VALUES ('HR', 'EMP_QTY_CK', 'EMP', 'C')"
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    reasons = {r.object_name: r.reason for r in result.residue if r.kind == "check"}
+    assert "not captured" in reasons["EMP_QTY_CK"]
+    assert "EMP_QTY_CK" not in result.sql.upper()
+
+
+def test_view_without_ddl_is_declined_by_name(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.execute(
+        "INSERT INTO objects (owner, name, type) VALUES ('HR', 'V_GHOST', 'VIEW')"
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    reasons = {r.object_name: r.reason for r in result.residue if r.kind == "view"}
+    assert "no DDL" in reasons["V_GHOST"]
+
+
+def test_case_sensitive_and_reserved_names_spell_consistently(tmp_path: Path) -> None:
+    """A quoted mixed-case table with a reserved-word column: the
+    table, its check, its comments, its grants, and a view over it
+    must all spell both names one way, or the DDL does not apply."""
+    db = tmp_path / "inv.db"
+    conn = open_db(db)
+    conn.executescript(
+        """
+        INSERT INTO objects (owner, name, type) VALUES
+          ('HR', 'MixedDept', 'TABLE'), ('HR', 'V_MIXED', 'VIEW');
+        INSERT INTO tables (owner, table_name, temporary)
+          VALUES ('HR', 'MixedDept', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'MixedDept', 'ID',    1, 'NUMBER', 22, 10, 0, 'N'),
+          ('HR', 'MixedDept', 'LIMIT', 2, 'NUMBER', 22, 5,  0, 'Y');
+        INSERT INTO constraints (owner, constraint_name, table_name, type) VALUES
+          ('HR', 'MIXED_PK', 'MixedDept', 'P'),
+          ('HR', 'MIXED_CK', 'MixedDept', 'C');
+        INSERT INTO constraint_columns (owner, constraint_name, column_name, position)
+          VALUES ('HR', 'MIXED_PK', 'ID', 1);
+        INSERT INTO check_conditions (owner, constraint_name, condition, truncated)
+          VALUES ('HR', 'MIXED_CK', '"LIMIT" > 0', 0);
+        INSERT INTO indexes (owner, index_name, table_name, index_type, uniqueness,
+                             generated)
+          VALUES ('HR', 'MIXED_LIMIT_IX', 'MixedDept', 'NORMAL', 'NONUNIQUE', 'N');
+        INSERT INTO index_columns (owner, index_name, column_name, position)
+          VALUES ('HR', 'MIXED_LIMIT_IX', 'LIMIT', 1);
+        INSERT INTO table_comments (owner, table_name, comments)
+          VALUES ('HR', 'MixedDept', 'Case matters');
+        INSERT INTO column_comments (owner, table_name, column_name, comments)
+          VALUES ('HR', 'MixedDept', 'LIMIT', 'Reserved word');
+        INSERT INTO grants (grantee, owner, table_name, privilege, grantable)
+          VALUES ('APP_RO', 'HR', 'MixedDept', 'SELECT', 'NO');
+        INSERT INTO ddl (owner, name, type, ddl, parse_ok, parse_quality) VALUES
+          ('HR', 'V_MIXED', 'VIEW',
+           'CREATE OR REPLACE VIEW "HR"."V_MIXED" AS'
+           || ' SELECT "LIMIT" FROM "HR"."MixedDept" WHERE "LIMIT" > 1', 1, 'full');
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(db)
+    sql = result.sql
+    assert 'CREATE TABLE "MixedDept" (' in sql
+    assert re.search(r'^\s+"limit" (integer|smallint|numeric)', sql, re.MULTILINE)
+    assert 'ALTER TABLE "MixedDept" ADD CONSTRAINT mixed_ck CHECK ("limit" > 0);' in sql
+    assert 'CREATE INDEX mixed_limit_ix ON "MixedDept" ("limit");' in sql
+    assert "COMMENT ON TABLE \"MixedDept\" IS 'Case matters';" in sql
+    assert 'COMMENT ON COLUMN "MixedDept"."limit" IS \'Reserved word\';' in sql
+    assert 'GRANT SELECT ON "MixedDept" TO app_ro;' in sql
+    assert 'FROM "MixedDept"' in sql and '"limit" > 1' in sql
+    for wrong in ('"LIMIT"', "mixeddept", '"MIXEDDEPT"'):
+        assert wrong not in sql
+    assert not [r for r in result.residue if r.kind not in ("note",)]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1495,3 +1495,84 @@ def test_mview_whose_query_does_not_fit_its_container_declines(
     }
     assert "yields 3 columns but the container has 2" in reasons["MV_WIDE"]
     assert "two output columns alike" in reasons["MV_TWICE"]
+
+
+def test_implicit_conversions_and_btree_less_types_decline(tmp_path: Path) -> None:
+    db = tmp_path / "inv.db"
+    conn = open_db(db)
+    conn.executescript(
+        """
+        INSERT INTO tables (owner, table_name, temporary) VALUES ('HR', 'DOCS', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'DOCS', 'ID',    1, 'NUMBER',   22, 10, 0, 'N'),
+          ('HR', 'DOCS', 'TITLE', 2, 'VARCHAR2', 80, NULL, NULL, 'Y'),
+          ('HR', 'DOCS', 'BODY',  3, 'XMLTYPE',  2000, NULL, NULL, 'Y'),
+          ('HR', 'DOCS', 'RAWID', 4, 'RAW',      16, NULL, NULL, 'Y'),
+          ('HR', 'DOCS', 'BAND',  5, 'NUMBER',   22, 3, 0, 'Y');
+        INSERT INTO constraints (owner, constraint_name, table_name, type) VALUES
+          ('HR', 'DOCS_PK', 'DOCS', 'P'),
+          ('HR', 'DOCS_BODY_UK', 'DOCS', 'U'),
+          ('HR', 'DOCS_TITLE_CK', 'DOCS', 'C'),
+          ('HR', 'DOCS_BAND_CK', 'DOCS', 'C');
+        INSERT INTO constraint_columns (owner, constraint_name, column_name, position)
+          VALUES ('HR', 'DOCS_PK', 'ID', 1), ('HR', 'DOCS_BODY_UK', 'BODY', 1);
+        INSERT INTO check_conditions (owner, constraint_name, condition, truncated)
+          VALUES ('HR', 'DOCS_TITLE_CK', 'NVL("TITLE", 0) <> 0', 0),
+                 ('HR', 'DOCS_BAND_CK', 'NVL("BAND", 0) >= 0', 0);
+        INSERT INTO indexes (owner, index_name, table_name, index_type, uniqueness,
+                             generated) VALUES
+          ('HR', 'DOCS_BODY_IX', 'DOCS', 'NORMAL', 'NONUNIQUE', 'N'),
+          ('HR', 'DOCS_UPPER_ID_IX', 'DOCS', 'FUNCTION-BASED NORMAL', 'NONUNIQUE', 'N'),
+          ('HR', 'DOCS_UPPER_TITLE_IX', 'DOCS', 'FUNCTION-BASED NORMAL', 'NONUNIQUE',
+           'N');
+        INSERT INTO index_columns (owner, index_name, column_name, position) VALUES
+          ('HR', 'DOCS_BODY_IX', 'BODY', 1),
+          ('HR', 'DOCS_UPPER_ID_IX', 'SYS_NC00006$', 1),
+          ('HR', 'DOCS_UPPER_TITLE_IX', 'SYS_NC00007$', 1);
+        INSERT INTO index_expressions (owner, index_name, position, expression,
+                                       truncated) VALUES
+          ('HR', 'DOCS_UPPER_ID_IX', 1, 'UPPER("ID")', 0),
+          ('HR', 'DOCS_UPPER_TITLE_IX', 1, 'UPPER("TITLE")', 0);
+        INSERT INTO column_defaults (owner, table_name, column_name, default_text,
+                                     virtual, truncated)
+          VALUES ('HR', 'DOCS', 'RAWID', 'HEXTORAW(''FF'')', 'NO', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(db)
+    sql = result.sql
+    assert "rawid bytea DEFAULT DECODE('FF', 'hex')" in sql
+    assert "ADD CONSTRAINT docs_band_ck CHECK (COALESCE(band, 0) >= 0);" in sql
+    assert "CREATE INDEX docs_upper_title_ix ON docs ((UPPER(title)));" in sql
+    for gone in ("docs_body_uk", "docs_title_ck", "docs_body_ix", "docs_upper_id_ix"):
+        assert gone not in sql
+    reasons = {r.object_name: r.reason for r in result.residue}
+    assert "no btree operator class" in reasons["DOCS_BODY_UK"]
+    assert "no btree operator class" in reasons["DOCS_BODY_IX"]
+    assert "UPPER over number column ID" in reasons["DOCS_UPPER_ID_IX"]
+    assert "COALESCE mixes number and text" in reasons["DOCS_TITLE_CK"]
+
+
+def test_unique_index_on_partitioned_table_needs_the_key(parts_db: Path) -> None:
+    conn = sqlite3.connect(parts_db)
+    conn.executescript(
+        """
+        INSERT INTO indexes (owner, index_name, table_name, index_type, uniqueness,
+                             generated) VALUES
+          ('HR', 'PART_UQ_BAD', 'LH', 'NORMAL', 'UNIQUE', 'N'),
+          ('HR', 'PART_UQ_GOOD', 'LH', 'NORMAL', 'UNIQUE', 'N');
+        INSERT INTO index_columns (owner, index_name, column_name, position) VALUES
+          ('HR', 'PART_UQ_BAD', 'ID', 1),
+          ('HR', 'PART_UQ_GOOD', 'ID', 1), ('HR', 'PART_UQ_GOOD', 'CODE', 2);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(parts_db)
+    assert "CREATE UNIQUE INDEX part_uq_good ON lh (id, code);" in result.sql
+    assert "part_uq_bad" not in result.sql
+    reasons = {r.object_name: r.reason for r in result.residue}
+    assert "every partition key; CODE is missing" in reasons["PART_UQ_BAD"]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1131,3 +1131,119 @@ def test_case_sensitive_and_reserved_names_spell_consistently(tmp_path: Path) ->
     for wrong in ('"LIMIT"', "mixeddept", '"MIXEDDEPT"'):
         assert wrong not in sql
     assert not [r for r in result.residue if r.kind not in ("note",)]
+
+
+def test_sequence_default_becomes_nextval(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO sequences (owner, sequence_name, min_value, max_value,
+                               increment_by, cycle_flag, cache_size, last_number)
+          VALUES ('HR', 'EMP_SEQ', '1', '9999999999999999999999999999', '1', 'N',
+                  '20', '1000'),
+                 ('HR', 'DEAD_SEQ', '1', '100', '1', 'N', '20', '500');
+        INSERT INTO column_defaults (owner, table_name, column_name, default_text,
+                                     virtual, truncated)
+          VALUES ('HR', 'EMP', 'EMP_ID', '"HR"."EMP_SEQ"."NEXTVAL"', 'NO', 0),
+                 ('HR', 'EMP', 'DEPT_ID', 'DEAD_SEQ.NEXTVAL', 'NO', 0),
+                 ('HR', 'DEPT', 'NAME', 'EMPTY_CLOB()', 'NO', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    sql = result.sql
+    assert "emp_id bigint DEFAULT nextval('emp_seq') NOT NULL" in sql
+    assert "CREATE SEQUENCE emp_seq INCREMENT BY 1 MINVALUE 1 START WITH 1000" in sql
+    assert "DEAD_SEQ" not in sql.upper().replace("DEAD_SEQ,", "")
+    reasons = {r.object_name: r.reason for r in result.residue}
+    assert "outside its bounds" in reasons["DEAD_SEQ"]
+    assert "not in the converted set" in reasons["EMP.DEPT_ID"]
+    assert "name varchar(50) DEFAULT '' NOT NULL" in sql
+
+
+def test_partition_by_virtual_or_dropped_column_is_declined(tmp_path: Path) -> None:
+    db = tmp_path / "inv.db"
+    conn = open_db(db)
+    conn.executescript(
+        """
+        INSERT INTO tables (owner, table_name, temporary) VALUES
+          ('HR', 'BY_VIRTUAL', 'N'), ('HR', 'BY_GONE', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'BY_VIRTUAL', 'ID',    1, 'NUMBER', 22, 10, 0, 'N'),
+          ('HR', 'BY_VIRTUAL', 'PRICE', 2, 'NUMBER', 22, 10, 2, 'Y'),
+          ('HR', 'BY_VIRTUAL', 'BAND',  3, 'NUMBER', 22, 10, 0, 'Y'),
+          ('HR', 'BY_GONE', 'ID',  1, 'NUMBER', 22, 10, 0, 'N'),
+          ('HR', 'BY_GONE', 'DOC', 2, 'BFILE', 530, NULL, NULL, 'Y');
+        INSERT INTO column_defaults (owner, table_name, column_name, default_text,
+                                     virtual, truncated)
+          VALUES ('HR', 'BY_VIRTUAL', 'BAND', '"PRICE" * 2', 'YES', 0);
+        INSERT INTO part_tables (owner, table_name, partitioning_type,
+                                 subpartitioning_type, partition_count, interval)
+          VALUES ('HR', 'BY_VIRTUAL', 'LIST', 'NONE', 1, NULL),
+                 ('HR', 'BY_GONE', 'HASH', 'NONE', 2, NULL);
+        INSERT INTO part_key_columns (owner, table_name, column_name, position)
+          VALUES ('HR', 'BY_VIRTUAL', 'BAND', 1), ('HR', 'BY_GONE', 'DOC', 1);
+        INSERT INTO part_partitions (owner, table_name, partition_name, position,
+                                     high_value, truncated)
+          VALUES ('HR', 'BY_VIRTUAL', 'P1', 1, '1, 2', 0),
+                 ('HR', 'BY_GONE', 'P1', 1, NULL, 0),
+                 ('HR', 'BY_GONE', 'P2', 2, NULL, 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(db)
+    assert "PARTITION BY" not in result.sql
+    assert "GENERATED ALWAYS AS (price * 2) STORED" in result.sql
+    reasons = {
+        r.object_name: r.reason for r in result.residue if r.kind == "partitioning"
+    }
+    assert "virtual column" in reasons["BY_VIRTUAL"]
+    assert "was not converted" in reasons["BY_GONE"]
+
+
+def test_trunc_over_dates_declines_where_types_are_known(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO constraints (owner, constraint_name, table_name, type)
+          VALUES ('HR', 'EMP_HIRED_CK', 'EMP', 'C'),
+                 ('HR', 'EMP_SAL_RND_CK', 'EMP', 'C');
+        INSERT INTO check_conditions (owner, constraint_name, condition, truncated)
+          VALUES ('HR', 'EMP_HIRED_CK', 'TRUNC("HIRED") = "HIRED"', 0),
+                 ('HR', 'EMP_SAL_RND_CK', 'ROUND("SALARY") > 0', 0);
+        INSERT INTO indexes (owner, index_name, table_name, index_type, uniqueness,
+                             generated)
+          VALUES ('HR', 'EMP_HIRED_DAY_IX', 'EMP', 'FUNCTION-BASED NORMAL',
+                  'NONUNIQUE', 'N'),
+                 ('HR', 'EMP_HIRED_DESC_IX', 'EMP', 'FUNCTION-BASED NORMAL',
+                  'NONUNIQUE', 'N');
+        INSERT INTO index_columns (owner, index_name, column_name, position)
+          VALUES ('HR', 'EMP_HIRED_DAY_IX', 'SYS_NC00010$', 1),
+                 ('HR', 'EMP_HIRED_DESC_IX', 'SYS_NC00011$', 1);
+        INSERT INTO index_expressions (owner, index_name, position, expression,
+                                       truncated)
+          VALUES ('HR', 'EMP_HIRED_DAY_IX', 1, 'TRUNC("HIRED")', 0),
+                 ('HR', 'EMP_HIRED_DESC_IX', 1, '"HIRED" DESC', 0);
+        INSERT INTO column_defaults (owner, table_name, column_name, default_text,
+                                     virtual, truncated)
+          VALUES ('HR', 'EMP', 'HIRED', 'TRUNC(SYSDATE)', 'NO', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    sql = result.sql
+    assert "ADD CONSTRAINT emp_sal_rnd_ck CHECK (ROUND(salary) > 0)" in sql
+    assert "emp_hired_ck" not in sql
+    assert "emp_hired_day_ix" not in sql and "emp_hired_desc_ix" not in sql
+    assert "DEFAULT TRUNC" not in sql
+    reasons = {r.object_name: r.reason for r in result.residue}
+    assert "date column HIRED" in reasons["EMP_HIRED_CK"]
+    assert "date column HIRED" in reasons["EMP_HIRED_DAY_IX"]
+    assert "recreate it from the source" in reasons["EMP_HIRED_DESC_IX"]
+    hired_notes = [r.reason for r in result.residue if r.object_name == "EMP.HIRED"]
+    assert any("date expression" in note for note in hired_notes)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1254,3 +1254,82 @@ def test_trunc_over_dates_declines_where_types_are_known(facts_db: Path) -> None
         "DATE_TRUNC('week', CURRENT_TIMESTAMP)"
     )
     assert _fold_expression("TRUNC(SYSDATE, 'W')") is None
+
+
+def test_foreign_keys_over_incompatible_types_decline(tmp_path: Path) -> None:
+    db = tmp_path / "inv.db"
+    conn = open_db(db)
+    conn.executescript(
+        """
+        INSERT INTO tables (owner, table_name, temporary) VALUES
+          ('HR', 'PARENT', 'N'), ('HR', 'CHILD', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'PARENT', 'ID',   1, 'NUMBER',   22, 10, 0, 'N'),
+          ('HR', 'PARENT', 'CODE', 2, 'CHAR',     3,  NULL, NULL, 'N'),
+          ('HR', 'CHILD',  'ID',   1, 'NUMBER',   22, 10, 0, 'N'),
+          ('HR', 'CHILD',  'P_ID', 2, 'NUMBER',   22, NULL, NULL, 'Y'),
+          ('HR', 'CHILD',  'Q_ID', 3, 'NUMBER',   22, 5, 0, 'Y'),
+          ('HR', 'CHILD',  'CODE', 4, 'VARCHAR2', 3,  NULL, NULL, 'Y'),
+          ('HR', 'CHILD',  'X_ID', 5, 'NUMBER',   22, 10, 0, 'Y');
+        INSERT INTO constraints (owner, constraint_name, table_name, type, ref_owner,
+                                 ref_constraint, delete_rule) VALUES
+          ('HR', 'PARENT_PK', 'PARENT', 'P', NULL, NULL, NULL),
+          ('HR', 'PARENT_CODE_UK', 'PARENT', 'U', NULL, NULL, NULL),
+          ('HR', 'CHILD_PK', 'CHILD', 'P', NULL, NULL, NULL),
+          ('HR', 'FK_NUMERIC', 'CHILD', 'R', 'HR', 'PARENT_PK', 'NO ACTION'),
+          ('HR', 'FK_NARROW', 'CHILD', 'R', 'HR', 'PARENT_PK', 'NO ACTION'),
+          ('HR', 'FK_CHARS', 'CHILD', 'R', 'HR', 'PARENT_CODE_UK', 'NO ACTION'),
+          ('HR', 'FK_COUNT', 'CHILD', 'R', 'HR', 'PARENT_PK', 'NO ACTION');
+        INSERT INTO constraint_columns (owner, constraint_name, column_name, position)
+          VALUES ('HR', 'PARENT_PK', 'ID', 1), ('HR', 'PARENT_CODE_UK', 'CODE', 1),
+                 ('HR', 'CHILD_PK', 'ID', 1),
+                 ('HR', 'FK_NUMERIC', 'P_ID', 1), ('HR', 'FK_NARROW', 'Q_ID', 1),
+                 ('HR', 'FK_CHARS', 'CODE', 1),
+                 ('HR', 'FK_COUNT', 'X_ID', 1), ('HR', 'FK_COUNT', 'Q_ID', 2);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(db)
+    sql = result.sql
+    # integer referencing bigint compares through the key; the rest cannot
+    assert "ADD CONSTRAINT fk_narrow FOREIGN KEY (q_id) REFERENCES parent (id)" in sql
+    reasons = {
+        r.object_name: r.reason for r in result.residue if r.kind == "foreign key"
+    }
+    assert "numeric while the referenced ID maps to bigint" in reasons["FK_NUMERIC"]
+    assert "varchar(3) while the referenced CODE maps to char(3)" in reasons["FK_CHARS"]
+    assert "2 columns reference a key of 1" in reasons["FK_COUNT"]
+    for name in ("fk_numeric", "fk_chars", "fk_count"):
+        assert name not in sql
+
+
+def test_defaults_that_postgres_cannot_evaluate_decline(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'DEPT', 'FLAG', 3, 'CHAR', 1, NULL, NULL, 'Y'),
+          ('HR', 'DEPT', 'OWNER_UID', 4, 'NUMBER', 22, 10, 0, 'Y'),
+          ('HR', 'DEPT', 'WHO', 5, 'VARCHAR2', 128, NULL, NULL, 'Y');
+        INSERT INTO column_defaults (owner, table_name, column_name, default_text,
+                                     virtual, truncated) VALUES
+          ('HR', 'DEPT', 'FLAG', char(39) || 'LONGER' || char(39), 'NO', 0),
+          ('HR', 'DEPT', 'OWNER_UID', 'UID', 'NO', 0),
+          ('HR', 'DEPT', 'WHO', 'USER', 'NO', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    sql = result.sql
+    assert "who varchar(128) DEFAULT CURRENT_USER" in sql
+    assert "flag char(1)," in sql and "LONGER" not in sql
+    assert "owner_uid bigint," in sql
+    notes = {r.object_name: r.reason for r in result.residue if r.kind == "note"}
+    assert "longer than the column" in notes["DEPT.FLAG"]
+    assert "UID, a column or Oracle pseudo-column" in notes["DEPT.OWNER_UID"]

--- a/tests/test_convert_code.py
+++ b/tests/test_convert_code.py
@@ -266,6 +266,8 @@ def test_happy_function_converts_mechanically(code_db: Path) -> None:
     assert "RAISE NOTICE '%'," in sql
     assert "c_fees CURSOR" in sql and "CURSOR c_fees" not in sql
     assert "FOR SELECT fee" in sql
+    # The cursor FOR loop's variable, which Oracle declares by itself.
+    assert "DECLARE\n  r record;" in sql
     assert "unique_violation" in sql
     assert "DUP_VAL_ON_INDEX" not in sql
     assert "t_fees.tag%TYPE" in sql

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -1,0 +1,40 @@
+"""The schema fuzzer's laws hold on a few fixed seeds.
+
+The nightly job runs a fresh window of seeds against live PostgreSQL;
+this keeps the generator and the two laws exercised on every commit.
+"""
+
+import importlib.util
+import logging
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[1] / "tools"
+
+
+def _tool(name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, TOOLS / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("seed", [1, 2, 3])
+def test_fuzz_seed_obeys_the_laws(seed: int, tmp_path: Path) -> None:
+    logging.getLogger("sqlglot").setLevel(logging.ERROR)
+    runner = _tool("fuzz_run")
+    result = runner.check_seed(seed, tmp_path, pg=None)
+    assert result.failures == []
+    assert result.objects > 40
+    assert result.ddl_bytes > 5000
+
+
+def test_fuzz_dump_is_deterministic(tmp_path: Path) -> None:
+    gen = _tool("fuzz_dump")
+    gen.generate(7, tmp_path / "a")
+    gen.generate(7, tmp_path / "b")
+    for path in sorted((tmp_path / "a").iterdir()):
+        assert path.read_bytes() == (tmp_path / "b" / path.name).read_bytes()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -401,3 +401,22 @@ def test_error_bearing_spool_degrades_not_crashes(tmp_path: Path) -> None:
     finally:
         conn.close()
     assert warn is not None and "skipped" in warn[0]
+
+
+def test_ddl_marker_accepts_names_with_spaces(tmp_path: Path) -> None:
+    dump = tmp_path / "dump"
+    dump.mkdir()
+    (dump / "ddl_views.sql").write_text(
+        "\n-- PGRECON_OBJECT VIEW HR.V WITH SPACE\n\n"
+        '  CREATE OR REPLACE VIEW "HR"."V WITH SPACE" AS SELECT 1 FROM dual;\n\n'
+        "-- PGRECON_OBJECT VIEW HR.V, COMMA\n\n"
+        '  CREATE OR REPLACE VIEW "HR"."V, COMMA" AS SELECT 2 FROM dual;\n',
+        encoding="utf-8",
+    )
+    db = tmp_path / "inv.db"
+    counts = load_dump(dump, db)
+    assert counts["ddl"] == 2
+    conn = sqlite3.connect(db)
+    names = {r[0] for r in conn.execute("SELECT name FROM ddl WHERE type = 'VIEW'")}
+    conn.close()
+    assert names == {"V WITH SPACE", "V, COMMA"}

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -436,6 +436,7 @@ class Estate:
         self.rng.shuffle(self.reserved_left)
         self.sys_counter = 8000
         self.objects: list[tuple[str, str, str]] = []
+        self.virtual: dict[str, set[str]] = {}
 
     # -- helpers ---------------------------------------------------------
 
@@ -767,22 +768,28 @@ class Estate:
             text = f"{q(OWNER)}.{q(seq)}.nextval"
             self.add("column_defaults.csv", OWNER, table.name, c.name, text, "NO", 0)
         elif roll < 0.30:
+            # A virtual column reads earlier plain columns only: Oracle
+            # refuses one virtual column over another.
+            earlier = table.columns[: table.columns.index(c)]
+            virtual = self.virtual.setdefault(table.name, set())
             others = [
-                o
-                for o in table.columns
-                if o is not c and o.data_type in NUMERIC and o.name != c.name
+                o for o in earlier if o.data_type in NUMERIC and o.name not in virtual
             ]
             if dtype in NUMERIC and others:
                 text = f"{q(others[0].name)} * 2"
+                virtual.add(c.name)
                 self.add(
                     "column_defaults.csv", OWNER, table.name, c.name, text, "YES", 0
                 )
             elif dtype in TEXTUAL:
                 texts = [
-                    o for o in table.columns if o is not c and o.data_type in TEXTUAL
+                    o
+                    for o in earlier
+                    if o.data_type in TEXTUAL and o.name not in virtual
                 ]
                 if texts:
                     text = f"UPPER({q(texts[0].name)})"
+                    virtual.add(c.name)
                     self.add(
                         "column_defaults.csv",
                         OWNER,
@@ -1053,7 +1060,16 @@ class Estate:
     def add_partitioning(self, table: Table) -> None:
         rng = self.rng
         name = table.name
-        dat, num, txt = table.dated(), table.numeric(), table.textual()
+        dat, num = table.dated(), table.numeric()
+        # List bounds must fit the key column, as Oracle insists.
+        txt = next(
+            (
+                c
+                for c in table.columns
+                if c.data_type in TEXTUAL and (c.length or 0) >= 8
+            ),
+            None,
+        )
         kinds = []
         if dat:
             kinds.append("RANGE_DATE")
@@ -1302,15 +1318,18 @@ class Estate:
             name = self.unique(f"MV_{base.name}_{i}"[:120])
             self.obj(name, "MATERIALIZED VIEW")
             self.obj(name, "TABLE")
+            # Aliases that cannot repeat the grouping column's name.
+            cnt = "HEADCOUNT" if txt.name.upper() != "HEADCOUNT" else "HEADCOUNT_2"
+            tot = "TOTAL" if txt.name.upper() != "TOTAL" else "TOTAL_2"
             if rng.random() < 0.3:
                 query = (
-                    f"SELECT {q(txt.name)}, COUNT(*) AS HEADCOUNT, 0 AS TOTAL"
+                    f"SELECT {q(txt.name)}, COUNT(*) AS {cnt}, 0 AS {tot}"
                     f" FROM {q(OWNER)}.NOPE"
                 )
             else:
                 query = (
-                    f"SELECT {q(txt.name)}, COUNT(*) AS HEADCOUNT,"
-                    f" SUM({q(num.name)}) AS TOTAL\n  FROM {q(base.name)}\n"
+                    f"SELECT {q(txt.name)}, COUNT(*) AS {cnt},"
+                    f" SUM({q(num.name)}) AS {tot}\n  FROM {q(base.name)}\n"
                     f" GROUP BY {q(txt.name)}"
                 )
             self.add(
@@ -1323,7 +1342,7 @@ class Estate:
             )
             self.add("tables.csv", OWNER, name, 12, 40, "NO", "N", "         1")
             for pos, (col, dtype) in enumerate(
-                ((txt.name, txt), ("HEADCOUNT", None), ("TOTAL", None)), start=1
+                ((txt.name, txt), (cnt, None), (tot, None)), start=1
             ):
                 self.add(
                     "columns.csv",

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -1249,16 +1249,25 @@ class Estate:
                 deps,
             )
         if roll < 0.50 and len(self.tables) > 1:
+            # Join columns of one family; Oracle rejects the rest too.
             other = rng.choice(self.tables)
-            deps.append((other.name, "TABLE"))
-            o1 = other.columns[0]
-            return (
-                ["A_COL", "B_COL"],
-                f"SELECT a.{q(c1.name)} AS A_COL, b.{q(o1.name)} AS B_COL\n"
-                f"  FROM {t} a, {q(other.name)} b\n"
-                f" WHERE a.{q(c1.name)} = b.{q(o1.name)} (+)",
-                deps,
-            )
+            pair = None
+            for family in (NUMERIC, TEXTUAL, {"DATE"}):
+                left = base.column(family)
+                right = other.column(family)
+                if left and right:
+                    pair = (left, right)
+                    break
+            if pair is not None:
+                deps.append((other.name, "TABLE"))
+                left, right = pair
+                return (
+                    ["A_COL", "B_COL"],
+                    f"SELECT a.{q(left.name)} AS A_COL, b.{q(right.name)} AS B_COL\n"
+                    f"  FROM {t} a, {q(other.name)} b\n"
+                    f" WHERE a.{q(left.name)} = b.{q(right.name)} (+)",
+                    deps,
+                )
         if roll < 0.58:
             return (
                 [c1.name, "LVL"],

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -1038,13 +1038,14 @@ class Estate:
                     self.add(
                         "index_columns.csv", OWNER, iname, f"SYS_NC0000{pos}$", pos
                     )
+                    torn = rng.random() < 0.1
                     self.add(
                         "index_expressions.csv",
                         OWNER,
                         iname,
                         pos,
-                        expr[:6] if rng.random() < 0.1 else expr,
-                        1 if rng.random() < 0.1 else 0,
+                        expr[:6] if torn else expr,
+                        1 if torn else 0,
                     )
                 else:
                     self.add("index_columns.csv", OWNER, iname, c.name, pos)
@@ -1269,11 +1270,21 @@ class Estate:
                     deps,
                 )
         if roll < 0.58:
+            # The hierarchy joins the key to a column of its own family.
+            mate = next(
+                (
+                    c
+                    for c in base.columns[1:]
+                    if (c.data_type in NUMERIC) == (c1.data_type in NUMERIC)
+                    and (c.data_type in TEXTUAL) == (c1.data_type in TEXTUAL)
+                ),
+                c2,
+            )
             return (
                 [c1.name, "LVL"],
                 f"SELECT {q(c1.name)}, LEVEL AS LVL\n  FROM {t}\n"
-                f" START WITH {q(c2.name)} IS NULL\n"
-                f" CONNECT BY PRIOR {q(c1.name)} = {q(c2.name)}",
+                f" START WITH {q(mate.name)} IS NULL\n"
+                f" CONNECT BY PRIOR {q(c1.name)} = {q(mate.name)}",
                 deps,
             )
         if roll < 0.66:

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -1113,9 +1113,22 @@ class Estate:
                 ("P_HIGH", "MAXVALUE", 0),
             ]
             if rng.random() < 0.15 and len(table.columns) > 2:
-                other = table.columns[1 if table.columns[1] is not num else 0]
-                key.append(other.name)
-                parts = [("P_A", "100, 'X'", 0), ("P_B", "MAXVALUE, MAXVALUE", 0)]
+                # A second key column with a bound of its own type.
+                other = next(
+                    (
+                        c
+                        for c in table.columns
+                        if c is not num and c.data_type in NUMERIC | TEXTUAL
+                    ),
+                    None,
+                )
+                if other is not None:
+                    key.append(other.name)
+                    second = "200" if other.data_type in NUMERIC else "'X'"
+                    parts = [
+                        ("P_A", f"100, {second}", 0),
+                        ("P_B", "MAXVALUE, MAXVALUE", 0),
+                    ]
         elif kind == "LIST" and txt:
             ptype = "LIST"
             key = [txt.name]

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -1291,8 +1291,15 @@ class Estate:
                     if (c.data_type in NUMERIC) == (c1.data_type in NUMERIC)
                     and (c.data_type in TEXTUAL) == (c1.data_type in TEXTUAL)
                 ),
-                c2,
+                None,
             )
+            if mate is None:
+                # No column of the key's family: a plain projection instead.
+                return (
+                    [c1.name, c2.name],
+                    f"SELECT {q(c1.name)}, {q(c2.name)} FROM {t}",
+                    deps,
+                )
             return (
                 [c1.name, "LVL"],
                 f"SELECT {q(c1.name)}, LEVEL AS LVL\n  FROM {t}\n"

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -303,21 +303,6 @@ NUMERIC = {"NUMBER", "FLOAT", "BINARY_DOUBLE", "BINARY_FLOAT"}
 TEXTUAL = {"VARCHAR2", "NVARCHAR2", "CHAR", "NCHAR"}
 LOBS = {"CLOB", "NCLOB", "BLOB"}
 
-DEFAULTS = [
-    "SYSDATE ",
-    "SYSTIMESTAMP ",
-    "USER ",
-    "'N' ",
-    "0 ",
-    "NULL ",
-    "sys_guid() ",
-    "TO_DATE('2020-01-01', 'YYYY-MM-DD') ",
-    "TRUNC(SYSDATE) ",
-    "EMPTY_CLOB() ",
-    "'O''Brien' ",
-    "CURRENT_TIMESTAMP ",
-    "1.5 ",
-]
 
 COMMENT_TEXTS = [
     "Plain comment",
@@ -648,7 +633,7 @@ class Estate:
                     f'"{c.name}" IS NOT NULL',
                     0,
                 )
-            if c.data_type not in LOBS | {"LONG", "LONG RAW"} and rng.random() < 0.18:
+            if c.data_type not in {"LONG", "LONG RAW"} and rng.random() < 0.2:
                 self.add_default(table, c)
             if rng.random() < 0.2:
                 self.add(
@@ -729,25 +714,81 @@ class Estate:
         return text
 
     def add_default(self, table: Table, c: Column) -> None:
+        """A default Oracle would accept for the column's type."""
         rng = self.rng
+        dtype = c.data_type
+        if dtype in NUMERIC:
+            pool = ["0 ", "1.5 ", "-1 ", "NULL "]
+        elif dtype in TEXTUAL:
+            pool = [
+                "'N' ",
+                "USER ",
+                "'O''Brien' ",
+                "TO_CHAR(SYSDATE, 'YYYY') ",
+                "SYS_CONTEXT('USERENV', 'SESSION_USER') ",
+                "sys_guid() ",
+                "NULL ",
+            ]
+        elif dtype == "DATE" or dtype.startswith("TIMESTAMP"):
+            pool = [
+                "SYSDATE ",
+                "SYSTIMESTAMP ",
+                "TRUNC(SYSDATE) ",
+                "TO_DATE('2020-01-01', 'YYYY-MM-DD') ",
+                "CURRENT_TIMESTAMP ",
+            ]
+        elif dtype in ("CLOB", "NCLOB"):
+            pool = ["EMPTY_CLOB() "]
+        elif dtype == "BLOB":
+            pool = ["EMPTY_BLOB() "]
+        elif dtype == "RAW":
+            pool = ["sys_guid() ", "HEXTORAW('FF') "]
+        else:
+            pool = ["NULL "]
         roll = rng.random()
-        if roll < 0.12 and c.data_type == "NUMBER" and self.sequences:
-            text = f'{q(OWNER)}.{q(rng.choice(self.sequences))}."NEXTVAL"'
-            self.add("column_defaults.csv", OWNER, table.name, c.name, text, "NO", 0)
-        elif roll < 0.20 and c.data_type == "NUMBER":
+        if roll < 0.12 and dtype == "NUMBER" and self.sequences:
+            seq = rng.choice(self.sequences)
+            spelled = rng.choice(
+                [
+                    f'{q(OWNER)}.{q(seq)}."NEXTVAL"',
+                    f"{q(OWNER)}.{q(seq)}.nextval",
+                    f"{q(seq)}.NEXTVAL",
+                ]
+            )
+            self.add("column_defaults.csv", OWNER, table.name, c.name, spelled, "NO", 0)
+        elif roll < 0.20 and dtype == "NUMBER":
             seq = f"ISEQ$$_{self.sys_counter + 70000}"
             self.sysname()
             self.obj(seq, "SEQUENCE")
             self.add("sequences.csv", OWNER, seq, "1", "9" * 28, "1", "N", "20", "41")
             text = f"{q(OWNER)}.{q(seq)}.nextval"
             self.add("column_defaults.csv", OWNER, table.name, c.name, text, "NO", 0)
-        elif roll < 0.30 and len(table.columns) > 2:
-            others = [o for o in table.columns if o is not c and o.data_type in NUMERIC]
-            if others:
+        elif roll < 0.30:
+            others = [
+                o
+                for o in table.columns
+                if o is not c and o.data_type in NUMERIC and o.name != c.name
+            ]
+            if dtype in NUMERIC and others:
                 text = f"{q(others[0].name)} * 2"
                 self.add(
                     "column_defaults.csv", OWNER, table.name, c.name, text, "YES", 0
                 )
+            elif dtype in TEXTUAL:
+                texts = [
+                    o for o in table.columns if o is not c and o.data_type in TEXTUAL
+                ]
+                if texts:
+                    text = f"UPPER({q(texts[0].name)})"
+                    self.add(
+                        "column_defaults.csv",
+                        OWNER,
+                        table.name,
+                        c.name,
+                        text,
+                        "YES",
+                        0,
+                    )
         elif roll < 0.36:
             self.add(
                 "column_defaults.csv",
@@ -764,7 +805,7 @@ class Estate:
                 OWNER,
                 table.name,
                 c.name,
-                rng.choice(DEFAULTS),
+                rng.choice(pool),
                 "NO",
                 0,
             )

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -1,0 +1,1829 @@
+"""Generate an adversarial extraction dump from a seed.
+
+The dump is shaped exactly like the SQL*Plus spools the packaged
+script produces - one blank line, a quoted CSV header, rows - but the
+content is chosen to hurt: identifiers past PostgreSQL's 63 bytes in
+ASCII and in Hangul, names that collide once Oracle's separate
+namespaces fold into pg_class, reserved words as column names, every
+Oracle data type the catalog can spell, partition layouts of every
+kind, sequences with 28-digit bounds, views over views, stored code
+that must convert next to code that must refuse, and spools that
+carry an Oracle error, a foreign code page, or a torn last row where
+data should be.
+
+    uv run python tools/fuzz_dump.py --seed 17 fuzz-work/seed-17
+
+Same seed, same dump, byte for byte. tools/fuzz_run.py drives many
+seeds through load, report, convert, and a live PostgreSQL apply and
+checks the converter's two laws on each one.
+"""
+
+import argparse
+import csv
+import json
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+
+OWNER = "FUZZ"
+STAMP = "2025-06-01 09:00:00"
+
+HEADERS: dict[str, list[str]] = {
+    "meta.csv": ["KEY", "VALUE"],
+    "objects.csv": [
+        "OWNER",
+        "OBJECT_NAME",
+        "OBJECT_TYPE",
+        "STATUS",
+        "CREATED",
+        "LAST_DDL_TIME",
+    ],
+    "tables.csv": [
+        "OWNER",
+        "TABLE_NAME",
+        "NUM_ROWS",
+        "AVG_ROW_LEN",
+        "PARTITIONED",
+        "TEMPORARY",
+        "DEGREE",
+    ],
+    "columns.csv": [
+        "OWNER",
+        "TABLE_NAME",
+        "COLUMN_NAME",
+        "COLUMN_ID",
+        "DATA_TYPE",
+        "DATA_LENGTH",
+        "DATA_PRECISION",
+        "DATA_SCALE",
+        "NULLABLE",
+    ],
+    "source.csv": ["OWNER", "NAME", "TYPE", "LINE", "TEXT"],
+    "features.csv": ["FEATURE", "DETAIL", "CNT"],
+    "dependencies.csv": [
+        "OWNER",
+        "NAME",
+        "TYPE",
+        "REFERENCED_OWNER",
+        "REFERENCED_NAME",
+        "REFERENCED_TYPE",
+    ],
+    "constraints.csv": [
+        "OWNER",
+        "CONSTRAINT_NAME",
+        "TABLE_NAME",
+        "CONSTRAINT_TYPE",
+        "STATUS",
+        "R_OWNER",
+        "R_CONSTRAINT_NAME",
+        "DELETE_RULE",
+    ],
+    "constraint_columns.csv": ["OWNER", "CONSTRAINT_NAME", "COLUMN_NAME", "POSITION"],
+    "check_conditions.csv": ["OWNER", "CONSTRAINT_NAME", "CONDITION", "TRUNCATED"],
+    "indexes.csv": [
+        "OWNER",
+        "INDEX_NAME",
+        "TABLE_NAME",
+        "INDEX_TYPE",
+        "UNIQUENESS",
+        "STATUS",
+        "GENERATED",
+        "DEGREE",
+    ],
+    "index_columns.csv": ["OWNER", "INDEX_NAME", "COLUMN_NAME", "COLUMN_POSITION"],
+    "index_expressions.csv": [
+        "OWNER",
+        "INDEX_NAME",
+        "COLUMN_POSITION",
+        "COLUMN_EXPRESSION",
+        "TRUNCATED",
+    ],
+    "part_tables.csv": [
+        "OWNER",
+        "TABLE_NAME",
+        "PARTITIONING_TYPE",
+        "SUBPARTITIONING_TYPE",
+        "PARTITION_COUNT",
+        "INTERVAL",
+    ],
+    "part_key_columns.csv": ["OWNER", "NAME", "COLUMN_NAME", "COLUMN_POSITION"],
+    "part_subkey_columns.csv": ["OWNER", "NAME", "COLUMN_NAME", "COLUMN_POSITION"],
+    "part_partitions.csv": [
+        "OWNER",
+        "TABLE_NAME",
+        "PARTITION_NAME",
+        "POSITION",
+        "HIGH_VALUE",
+        "TRUNCATED",
+    ],
+    "part_subpartitions.csv": [
+        "OWNER",
+        "TABLE_NAME",
+        "PARTITION_NAME",
+        "SUBPARTITION_NAME",
+        "POSITION",
+        "HIGH_VALUE",
+        "TRUNCATED",
+    ],
+    "sequences.csv": [
+        "OWNER",
+        "SEQUENCE_NAME",
+        "MIN_VALUE",
+        "MAX_VALUE",
+        "INCREMENT_BY",
+        "CYCLE_FLAG",
+        "CACHE_SIZE",
+        "LAST_NUMBER",
+    ],
+    "column_defaults.csv": [
+        "OWNER",
+        "TABLE_NAME",
+        "COLUMN_NAME",
+        "DEFAULT_TEXT",
+        "VIRTUAL",
+        "TRUNCATED",
+    ],
+    "synonyms.csv": ["OWNER", "SYNONYM_NAME", "TABLE_OWNER", "TABLE_NAME", "DB_LINK"],
+    "triggers.csv": [
+        "OWNER",
+        "TRIGGER_NAME",
+        "TRIGGER_TYPE",
+        "TRIGGERING_EVENT",
+        "TABLE_NAME",
+        "STATUS",
+    ],
+    "db_links.csv": ["OWNER", "DB_LINK", "USERNAME", "HOST"],
+    "part_indexes.csv": ["OWNER", "INDEX_NAME", "TABLE_NAME", "LOCALITY"],
+    "mviews.csv": ["OWNER", "MVIEW_NAME", "REWRITE_ENABLED", "REFRESH_METHOD", "QUERY"],
+    "license.csv": ["KEY", "VALUE"],
+    "grants.csv": ["GRANTEE", "OWNER", "TABLE_NAME", "PRIVILEGE", "GRANTABLE"],
+    "table_comments.csv": ["OWNER", "TABLE_NAME", "COMMENTS"],
+    "column_comments.csv": ["OWNER", "TABLE_NAME", "COLUMN_NAME", "COMMENTS"],
+    "nls.csv": ["KEY", "VALUE"],
+    "feature_usage.csv": [
+        "NAME",
+        "VERSION",
+        "DETECTED_USAGES",
+        "CURRENTLY_USED",
+        "LAST_USAGE",
+    ],
+    "plan_management.csv": ["KIND", "NAME", "ENABLED"],
+}
+
+TABLE_WORDS = [
+    "ORDERS",
+    "EMP",
+    "DEPT",
+    "SALES",
+    "AUDIT",
+    "LEDGER",
+    "INVOICE",
+    "STOCK",
+    "CUSTOMER",
+    "PAYMENT",
+    "SHIPMENT",
+    "EVENT",
+    "RATE",
+    "REGION",
+    "TICKET",
+    "ASSET",
+]
+COLUMN_WORDS = [
+    "NAME",
+    "CREATED",
+    "AMOUNT",
+    "STATUS",
+    "QTY",
+    "NOTE",
+    "EMAIL",
+    "PRICE",
+    "UPDATED",
+    "CODE",
+    "FLAG",
+    "TOTAL",
+    "REGION",
+    "PAYLOAD",
+    "DOC",
+    "RANK",
+]
+# Reserved in PostgreSQL, legal as quoted identifiers in Oracle.
+RESERVED = [
+    "ORDER",
+    "USER",
+    "GROUP",
+    "SELECT",
+    "END",
+    "CHECK",
+    "LIMIT",
+    "OFFSET",
+    "WINDOW",
+    "TABLE",
+    "COLUMN",
+    "DEFAULT",
+    "ANALYZE",
+    "CAST",
+    "PRIMARY",
+    "DESC",
+    "FROM",
+    "WHERE",
+    "LEVEL",
+    "START",
+    "ARRAY",
+    "LATERAL",
+]
+# Hangul and CJK words: three bytes per character in UTF-8, so a
+# 25-character name is 75 bytes, past the limit while short to look at.
+CJK = [
+    "\uc9c1\uc6d0",
+    "\ubd80\uc11c",
+    "\u90e8\u9580",
+    "\u793e\u54e1",
+    "\u9867\u5ba2",
+    "\uc8fc\ubb38",
+    "\ud14c\uc774\ube14",
+]
+
+# (catalog data_type, data_length, precision, scale, DDL spelling, weight)
+TYPES: list[tuple[str, int, int | None, int | None, str, int]] = [
+    ("NUMBER", 22, None, None, "NUMBER", 10),
+    ("NUMBER", 22, 10, 0, "NUMBER(10,0)", 10),
+    ("NUMBER", 22, 38, 0, "NUMBER(38,0)", 3),
+    ("NUMBER", 22, 12, 2, "NUMBER(12,2)", 8),
+    ("NUMBER", 22, None, 0, "NUMBER(*,0)", 3),
+    ("NUMBER", 22, 5, -2, "NUMBER(5,-2)", 1),
+    ("NUMBER", 22, 5, 10, "NUMBER(5,10)", 1),
+    ("NUMBER", 22, 1, 0, "NUMBER(1,0)", 4),
+    ("FLOAT", 22, 126, None, "FLOAT(126)", 2),
+    ("BINARY_DOUBLE", 8, None, None, "BINARY_DOUBLE", 2),
+    ("BINARY_FLOAT", 4, None, None, "BINARY_FLOAT", 1),
+    ("VARCHAR2", 1, None, None, "VARCHAR2(1 BYTE)", 4),
+    ("VARCHAR2", 30, None, None, "VARCHAR2(30 BYTE)", 12),
+    ("VARCHAR2", 255, None, None, "VARCHAR2(255 CHAR)", 8),
+    ("VARCHAR2", 4000, None, None, "VARCHAR2(4000 BYTE)", 4),
+    ("VARCHAR2", 32767, None, None, "VARCHAR2(32767 BYTE)", 1),
+    ("NVARCHAR2", 400, None, None, "NVARCHAR2(200)", 2),
+    ("CHAR", 1, None, None, "CHAR(1 BYTE)", 4),
+    ("CHAR", 10, None, None, "CHAR(10 BYTE)", 2),
+    ("NCHAR", 10, None, None, "NCHAR(5)", 1),
+    ("DATE", 7, None, None, "DATE", 10),
+    ("TIMESTAMP(6)", 11, None, 6, "TIMESTAMP (6)", 6),
+    ("TIMESTAMP(9)", 11, None, 9, "TIMESTAMP (9)", 1),
+    ("TIMESTAMP(0)", 7, None, 0, "TIMESTAMP (0)", 1),
+    ("TIMESTAMP(6) WITH TIME ZONE", 13, None, 6, "TIMESTAMP (6) WITH TIME ZONE", 3),
+    (
+        "TIMESTAMP(6) WITH LOCAL TIME ZONE",
+        11,
+        None,
+        6,
+        "TIMESTAMP (6) WITH LOCAL TIME ZONE",
+        2,
+    ),
+    ("INTERVAL DAY(2) TO SECOND(6)", 11, 2, 6, "INTERVAL DAY (2) TO SECOND (6)", 2),
+    ("INTERVAL YEAR(2) TO MONTH", 5, 2, None, "INTERVAL YEAR (2) TO MONTH", 1),
+    ("CLOB", 4000, None, None, "CLOB", 5),
+    ("NCLOB", 4000, None, None, "NCLOB", 1),
+    ("BLOB", 4000, None, None, "BLOB", 4),
+    ("LONG", 0, None, None, "LONG", 2),
+    ("LONG RAW", 0, None, None, "LONG RAW", 1),
+    ("RAW", 16, None, None, "RAW(16)", 3),
+    ("RAW", 2000, None, None, "RAW(2000)", 1),
+    ("ROWID", 10, None, None, "ROWID", 1),
+    ("UROWID", 4000, None, None, "UROWID(4000)", 1),
+    ("XMLTYPE", 2000, None, None, '"SYS"."XMLTYPE"', 2),
+    ("BFILE", 530, None, None, "BFILE", 1),
+    ("SDO_GEOMETRY", 1, None, None, '"MDSYS"."SDO_GEOMETRY"', 1),
+    ("ANYDATA", 1, None, None, '"SYS"."ANYDATA"', 1),
+    ("ADDR_T", 1, None, None, '"FUZZ"."ADDR_T"', 1),
+    ("JSON", 8200, None, None, "JSON", 1),
+    ("BOOLEAN", 1, None, None, "BOOLEAN", 1),
+]
+TYPE_WEIGHTS = [t[5] for t in TYPES]
+
+NUMERIC = {"NUMBER", "FLOAT", "BINARY_DOUBLE", "BINARY_FLOAT"}
+TEXTUAL = {"VARCHAR2", "NVARCHAR2", "CHAR", "NCHAR"}
+LOBS = {"CLOB", "NCLOB", "BLOB"}
+
+DEFAULTS = [
+    "SYSDATE ",
+    "SYSTIMESTAMP ",
+    "USER ",
+    "'N' ",
+    "0 ",
+    "NULL ",
+    "sys_guid() ",
+    "TO_DATE('2020-01-01', 'YYYY-MM-DD') ",
+    "TRUNC(SYSDATE) ",
+    "EMPTY_CLOB() ",
+    "'O''Brien' ",
+    "CURRENT_TIMESTAMP ",
+    "1.5 ",
+]
+
+COMMENT_TEXTS = [
+    "Plain comment",
+    "Has 'quotes' inside",
+    "Two lines\nof comment",
+    "Caf\u00e9 latt\u00e9 with accents",
+    "\uc9c1\uc6d0 \ud14c\uc774\ube14 (Hangul)",
+    "Semi; colon -- and dashes",
+    "",
+]
+
+FEATURES = [
+    ("materialized_views", "schema total"),
+    ("db_links", "owned or public"),
+    ("vpd_policies", "row level security"),
+    ("scheduler_jobs", "schema total"),
+    ("legacy_jobs", "dbms_job"),
+    ("queues", "advanced queuing"),
+    ("triggers", "schema total"),
+    ("object_types", "user defined"),
+    ("partitioned_tables", "schema total"),
+    ("iot_tables", "index organized"),
+    ("external_tables", "schema total"),
+    ("temporary_tables", "global temporary"),
+]
+
+CHARSETS = ["AL32UTF8", "AL32UTF8", "WE8ISO8859P1", "KO16MSWIN949", "WE8MSWIN1252"]
+VERSIONS = [
+    ("Oracle Database 11g Enterprise Edition ", "11.2.0.4.0"),
+    ("Oracle Database 12c Enterprise Edition ", "12.2.0.1.0"),
+    ("Oracle Database 19c Enterprise Edition ", "19.0.0.0.0"),
+    ("Oracle Database 21c Express Edition ", "21.0.0.0.0"),
+    ("Oracle Database 23ai Free ", "23.0.0.0.0"),
+]
+
+ERROR_SPOOL = "\n\nERROR at line 1:\nORA-00942: table or view does not exist\n\n\n"
+
+
+def q(name: str) -> str:
+    """Quote an identifier the way Oracle SQL needs it."""
+    return '"' + name + '"'
+
+
+def esc(text: str) -> str:
+    return text.replace("'", "''")
+
+
+@dataclass
+class Column:
+    name: str
+    data_type: str
+    length: int | None
+    precision: int | None
+    scale: int | None
+    nullable: bool
+    ddl: str
+
+
+@dataclass
+class Table:
+    name: str
+    columns: list[Column] = field(default_factory=list)
+    pk: str | None = None
+    pk_cols: list[str] = field(default_factory=list)
+    uk: str | None = None
+    uk_cols: list[str] = field(default_factory=list)
+    partitioned: bool = False
+    temporary: bool = False
+    partition_clause: str = ""
+    plain: bool = True
+
+    def column(self, kinds: set[str]) -> Column | None:
+        for c in self.columns:
+            if c.data_type in kinds:
+                return c
+        return None
+
+    def numeric(self) -> Column | None:
+        return self.column(NUMERIC)
+
+    def textual(self) -> Column | None:
+        return self.column(TEXTUAL)
+
+    def dated(self) -> Column | None:
+        return self.column({"DATE"})
+
+
+@dataclass
+class Manifest:
+    """What the generator produced, for the runner's expectations."""
+
+    seed: int
+    objects: list[tuple[str, str, str]]
+    error_spools: list[str] = field(default_factory=list)
+    lossy_spools: list[str] = field(default_factory=list)
+    torn_spools: list[str] = field(default_factory=list)
+    missing_spools: list[str] = field(default_factory=list)
+
+    def as_json(self) -> str:
+        return json.dumps(
+            {
+                "seed": self.seed,
+                "objects": self.objects,
+                "error_spools": self.error_spools,
+                "lossy_spools": self.lossy_spools,
+                "torn_spools": self.torn_spools,
+                "missing_spools": self.missing_spools,
+            },
+            ensure_ascii=True,
+            indent=1,
+        )
+
+
+class Estate:
+    def __init__(self, seed: int) -> None:
+        self.seed = seed
+        self.rng = random.Random(seed)
+        self.rows: dict[str, list[list[object]]] = {name: [] for name in HEADERS}
+        self.ddl: dict[str, list[str]] = {
+            "ddl_tables.sql": [],
+            "ddl_views.sql": [],
+            "ddl_sequences.sql": [],
+        }
+        self.tables: list[Table] = []
+        self.views: list[tuple[str, list[str]]] = []
+        self.sequences: list[str] = []
+        self.routines: list[tuple[str, str]] = []
+        self.packages: list[str] = []
+        self.used_names: dict[str, bool] = {}
+        self.reserved_left = list(RESERVED)
+        self.rng.shuffle(self.reserved_left)
+        self.sys_counter = 8000
+        self.objects: list[tuple[str, str, str]] = []
+
+    # -- helpers ---------------------------------------------------------
+
+    def add(self, spool: str, *values: object) -> None:
+        self.rows[spool].append(list(values))
+
+    def obj(self, name: str, otype: str, status: str = "VALID") -> None:
+        self.add("objects.csv", OWNER, name, otype, status, STAMP, STAMP)
+        self.objects.append((OWNER, name, otype))
+
+    def sysname(self, prefix: str = "SYS_C00") -> str:
+        self.sys_counter += 1
+        return f"{prefix}{self.sys_counter}"
+
+    def unique(self, candidate: str) -> str:
+        name = candidate
+        while name in self.used_names:
+            name = f"{candidate}_{self.rng.randrange(10, 99)}"
+        self.used_names[name] = True
+        return name
+
+    def styled_name(self, base: str, i: int, allow_reserved: bool = True) -> str:
+        """A name in one of the adversarial styles."""
+        roll = self.rng.random()
+        if roll < 0.50:
+            return f"{base}_{i}"
+        if roll < 0.58 and allow_reserved and self.reserved_left:
+            return self.reserved_left.pop()
+        if roll < 0.66:
+            return f"Mixed{base.title()}{i}"
+        if roll < 0.72:
+            return f"{base}${i}#X"
+        if roll < 0.76:
+            return f"{base} WITH SPACE {i}"
+        if roll < 0.79:
+            return f"{base}, COMMA {i}"
+        if roll < 0.87:
+            return f"LONG_{base}_" + "X" * 66 + f"_{i}"
+        if roll < 0.94:
+            return f"{self.rng.choice(CJK)}_{base}_{i}"
+        return self.rng.choice(CJK[-1:]) * 8 + f"_{i}"
+
+    def pick_type(self) -> tuple[str, int, int | None, int | None, str]:
+        t = self.rng.choices(TYPES, weights=TYPE_WEIGHTS)[0]
+        return t[0], t[1], t[2], t[3], t[4]
+
+    # -- tables ----------------------------------------------------------
+
+    def make_tables(self) -> None:
+        count = self.rng.randint(12, 28)
+        for i in range(count):
+            self.make_table(i)
+        # A pair whose names agree on their first 63 bytes: PostgreSQL
+        # would fold them together, so the converter must refuse one.
+        if self.rng.random() < 0.6:
+            stem = "CLASH_" + "Z" * 57
+            for tag in ("A", "B"):
+                self.make_table(count + 1, forced_name=self.unique(f"{stem}_{tag}"))
+        # A table named exactly like a partition child of another one.
+        if self.rng.random() < 0.4:
+            parents = [t for t in self.tables if t.partitioned and t.plain]
+            if parents:
+                parent = self.rng.choice(parents)
+                self.make_table(
+                    count + 3, forced_name=self.unique(f"{parent.name}_P_1")
+                )
+
+    def make_table(self, i: int, forced_name: str | None = None) -> None:
+        rng = self.rng
+        word = rng.choice(TABLE_WORDS)
+        name = forced_name or self.unique(self.styled_name(word, i))
+        table = Table(name=name, plain=name.isidentifier() and name.isupper())
+        used: dict[str, bool] = {}
+
+        def col_name(base: str) -> str:
+            candidate = base
+            while candidate in used:
+                candidate = f"{base}_{rng.randrange(1, 99)}"
+            used[candidate] = True
+            return candidate
+
+        with_id = rng.random() < 0.85
+        if with_id:
+            table.columns.append(
+                Column(col_name("ID"), "NUMBER", 22, 10, 0, False, "NUMBER(10,0)")
+            )
+        for k in range(rng.randint(2, 9)):
+            dtype, length, precision, scale, ddl = self.pick_type()
+            base = rng.choice(COLUMN_WORDS)
+            roll = rng.random()
+            if roll < 0.10 and self.reserved_left:
+                base = self.reserved_left.pop()
+            elif roll < 0.16:
+                base = f"Mixed{base.title()}"
+            elif roll < 0.20:
+                base = f"{base}$#{k}"
+            elif roll < 0.25:
+                base = f"{rng.choice(CJK)}_{base}"
+            elif roll < 0.29:
+                base = "LONGCOL_" + "Y" * 60 + f"_{k}"
+            table.columns.append(
+                Column(
+                    col_name(base),
+                    dtype,
+                    length,
+                    precision,
+                    scale,
+                    rng.random() < 0.7,
+                    ddl,
+                )
+            )
+        table.temporary = not forced_name and rng.random() < 0.05
+
+        # Keys.
+        if with_id and rng.random() < 0.9:
+            table.pk = (
+                self.sysname()
+                if rng.random() < 0.3
+                else self.unique(f"PK_{name}"[:120])
+            )
+            table.pk_cols = [table.columns[0].name]
+            if rng.random() < 0.15 and len(table.columns) > 2:
+                second = table.columns[1]
+                if second.data_type not in LOBS | {"LONG", "LONG RAW"}:
+                    second.nullable = False
+                    table.pk_cols.append(second.name)
+        candidates = [
+            c for c in table.columns[1:] if c.data_type in TEXTUAL | {"DATE"} | NUMERIC
+        ]
+        if candidates and rng.random() < 0.3:
+            table.uk = self.unique(f"UK_{name}"[:120])
+            table.uk_cols = [rng.choice(candidates).name]
+
+        self.tables.append(table)
+        self.emit_table(table, i)
+
+    def emit_table(self, table: Table, i: int) -> None:
+        rng = self.rng
+        name = table.name
+        self.obj(name, "TABLE")
+        self.add(
+            "tables.csv",
+            OWNER,
+            name,
+            rng.choice([None, 0, 12, 4500, 1_200_000]),
+            rng.choice([None, 40, 180]),
+            "NO",
+            "Y" if table.temporary else "N",
+            "         1",
+        )
+        for pos, c in enumerate(table.columns, start=1):
+            self.add(
+                "columns.csv",
+                OWNER,
+                name,
+                c.name,
+                pos,
+                c.data_type,
+                c.length,
+                c.precision,
+                c.scale,
+                "Y" if c.nullable else "N",
+            )
+            if c.data_type in LOBS:
+                lob = f"SYS_LOB{self.sys_counter:07d}C{pos:05d}$$"
+                self.obj(lob, "LOB")
+                self.add(
+                    "indexes.csv",
+                    OWNER,
+                    f"SYS_IL{self.sys_counter:07d}C{pos:05d}$$",
+                    name,
+                    "LOB",
+                    "UNIQUE",
+                    "VALID",
+                    "Y",
+                    "1",
+                )
+                self.obj(f"SYS_IL{self.sys_counter:07d}C{pos:05d}$$", "INDEX")
+            if not c.nullable:
+                self.add(
+                    "constraints.csv",
+                    OWNER,
+                    self.sysname(),
+                    name,
+                    "C",
+                    "ENABLED",
+                    None,
+                    None,
+                    None,
+                )
+                self.add(
+                    "check_conditions.csv",
+                    OWNER,
+                    f"SYS_C00{self.sys_counter}",
+                    f'"{c.name}" IS NOT NULL',
+                    0,
+                )
+            if c.data_type not in LOBS | {"LONG", "LONG RAW"} and rng.random() < 0.18:
+                self.add_default(table, c)
+            if rng.random() < 0.2:
+                self.add(
+                    "column_comments.csv",
+                    OWNER,
+                    name,
+                    c.name,
+                    rng.choice(COMMENT_TEXTS),
+                )
+        if rng.random() < 0.35:
+            self.add("table_comments.csv", OWNER, name, rng.choice(COMMENT_TEXTS))
+
+        # Keys, their backing indexes, and the constraint rows.
+        for cname, cols, ctype in (
+            (table.pk, table.pk_cols, "P"),
+            (table.uk, table.uk_cols, "U"),
+        ):
+            if not cname:
+                continue
+            self.add(
+                "constraints.csv",
+                OWNER,
+                cname,
+                name,
+                ctype,
+                "DISABLED" if rng.random() < 0.05 else "ENABLED",
+                None,
+                None,
+                None,
+            )
+            for pos, col in enumerate(cols, start=1):
+                self.add("constraint_columns.csv", OWNER, cname, col, pos)
+            self.add(
+                "indexes.csv",
+                OWNER,
+                cname,
+                name,
+                "NORMAL",
+                "UNIQUE",
+                "VALID",
+                "Y" if cname.startswith("SYS_C") else "N",
+                "1",
+            )
+            self.obj(cname, "INDEX")
+            for pos, col in enumerate(cols, start=1):
+                self.add("index_columns.csv", OWNER, cname, col, pos)
+
+        self.add_foreign_keys(table)
+        self.add_checks(table)
+        self.add_indexes(table)
+        if not table.temporary and rng.random() < 0.3:
+            self.add_partitioning(table)
+        self.add_grants(name, "TABLE")
+        self.ddl["ddl_tables.sql"].append(self.table_ddl(table))
+
+    def table_ddl(self, table: Table) -> str:
+        cols = []
+        for c in table.columns:
+            line = f"\t{q(c.name)} {c.ddl}"
+            if not c.nullable:
+                line += " NOT NULL ENABLE"
+            cols.append(line)
+        if table.pk:
+            keys = ", ".join(q(c) for c in table.pk_cols)
+            cols.append(
+                f"\t CONSTRAINT {q(table.pk)} PRIMARY KEY ({keys})\n"
+                "  USING INDEX  ENABLE"
+            )
+        head = "GLOBAL TEMPORARY TABLE" if table.temporary else "TABLE"
+        body = ",\n".join(cols)
+        text = (
+            f"-- PGRECON_OBJECT TABLE {OWNER}.{table.name}\n\n"
+            f"  CREATE {head} {q(OWNER)}.{q(table.name)}\n   ({body}\n   ) "
+        )
+        if table.temporary:
+            text += "ON COMMIT PRESERVE ROWS "
+        text += table.partition_clause + ";\n"
+        return text
+
+    def add_default(self, table: Table, c: Column) -> None:
+        rng = self.rng
+        roll = rng.random()
+        if roll < 0.12 and c.data_type == "NUMBER" and self.sequences:
+            text = f'{q(OWNER)}.{q(rng.choice(self.sequences))}."NEXTVAL"'
+            self.add("column_defaults.csv", OWNER, table.name, c.name, text, "NO", 0)
+        elif roll < 0.20 and c.data_type == "NUMBER":
+            seq = f"ISEQ$$_{self.sys_counter + 70000}"
+            self.sysname()
+            self.obj(seq, "SEQUENCE")
+            self.add("sequences.csv", OWNER, seq, "1", "9" * 28, "1", "N", "20", "41")
+            text = f"{q(OWNER)}.{q(seq)}.nextval"
+            self.add("column_defaults.csv", OWNER, table.name, c.name, text, "NO", 0)
+        elif roll < 0.30 and len(table.columns) > 2:
+            others = [o for o in table.columns if o is not c and o.data_type in NUMERIC]
+            if others:
+                text = f"{q(others[0].name)} * 2"
+                self.add(
+                    "column_defaults.csv", OWNER, table.name, c.name, text, "YES", 0
+                )
+        elif roll < 0.36:
+            self.add(
+                "column_defaults.csv",
+                OWNER,
+                table.name,
+                c.name,
+                "TO_DATE('2020-01-01', 'YY",
+                "NO",
+                1,
+            )
+        else:
+            self.add(
+                "column_defaults.csv",
+                OWNER,
+                table.name,
+                c.name,
+                rng.choice(DEFAULTS),
+                "NO",
+                0,
+            )
+
+    def add_foreign_keys(self, table: Table) -> None:
+        rng = self.rng
+        parents = [t for t in self.tables[:-1] if t.pk]
+        if not parents or rng.random() > 0.5:
+            pass
+        else:
+            parent = rng.choice(parents)
+            self.foreign_key(table, parent, parent.pk or "", parent.pk_cols)
+        if table.pk and len(table.pk_cols) == 1 and rng.random() < 0.1:
+            self.foreign_key(table, table, table.pk, table.pk_cols, self_ref=True)
+        uk_parents = [t for t in self.tables[:-1] if t.uk]
+        if uk_parents and rng.random() < 0.15:
+            parent = rng.choice(uk_parents)
+            self.foreign_key(table, parent, parent.uk or "", parent.uk_cols)
+        if rng.random() < 0.06:
+            # A parent in another schema that is not in the dump.
+            cname = self.unique(f"FK_{table.name}_EXT"[:120])
+            col = self.fk_column(table, "EXT")
+            self.add(
+                "constraints.csv",
+                OWNER,
+                cname,
+                table.name,
+                "R",
+                "ENABLED",
+                "OTHER_SCHEMA",
+                "PK_ELSEWHERE",
+                "NO ACTION",
+            )
+            self.add("constraint_columns.csv", OWNER, cname, col, 1)
+
+    def fk_column(self, table: Table, tag: str) -> str:
+        base = f"{tag}_ID"
+        existing = {c.name for c in table.columns}
+        name = base
+        while name in existing:
+            name = f"{base}_{self.rng.randrange(1, 99)}"
+        col = Column(name, "NUMBER", 22, 10, 0, True, "NUMBER(10,0)")
+        table.columns.append(col)
+        self.add(
+            "columns.csv",
+            OWNER,
+            table.name,
+            name,
+            len(table.columns),
+            "NUMBER",
+            22,
+            10,
+            0,
+            "Y",
+        )
+        return name
+
+    def foreign_key(
+        self,
+        table: Table,
+        parent: Table,
+        ref_constraint: str,
+        ref_cols: list[str],
+        self_ref: bool = False,
+    ) -> None:
+        rng = self.rng
+        tag = "PARENT" if self_ref else parent.name[:12].replace(" ", "_")
+        cname = self.unique(f"FK_{table.name}_{tag}"[:120])
+        cols = [self.fk_column(table, tag) for _ in ref_cols]
+        if rng.random() < 0.05:
+            # Column count that does not match the referenced key.
+            cols.append(self.fk_column(table, tag + "_X"))
+        self.add(
+            "constraints.csv",
+            OWNER,
+            cname,
+            table.name,
+            "R",
+            "DISABLED" if rng.random() < 0.05 else "ENABLED",
+            OWNER,
+            ref_constraint,
+            rng.choice(["NO ACTION", "CASCADE", "SET NULL"]),
+        )
+        for pos, col in enumerate(cols, start=1):
+            self.add("constraint_columns.csv", OWNER, cname, col, pos)
+        if rng.random() < 0.5:
+            iname = self.unique(f"IX_{cname}"[:120])
+            self.add(
+                "indexes.csv",
+                OWNER,
+                iname,
+                table.name,
+                "NORMAL",
+                "NONUNIQUE",
+                "VALID",
+                "N",
+                "1",
+            )
+            self.obj(iname, "INDEX")
+            for pos, col in enumerate(cols, start=1):
+                self.add("index_columns.csv", OWNER, iname, col, pos)
+
+    def add_checks(self, table: Table) -> None:
+        rng = self.rng
+        if rng.random() > 0.55:
+            return
+        num = table.numeric()
+        txt = table.textual()
+        dat = table.dated()
+        pool: list[str] = []
+        if num:
+            n = q(num.name)
+            pool += [f"{n} > 0", f"{n} BETWEEN 1 AND 10", f"NVL({n}, 0) >= 0"]
+        if txt:
+            t = q(txt.name)
+            pool += [
+                f"{t} IN ('A', 'B', 'C')",
+                f"LENGTH({t}) < 50",
+                f"REGEXP_LIKE({t}, '^[A-Z]')",
+                f"UPPER({t}) = {t}",
+                f"DECODE({t}, 'X', 1, 0) = 1",
+                f"{t} <> ''",
+            ]
+        if dat:
+            d = q(dat.name)
+            pool += [
+                f"{d} > TO_DATE('2000-01-01', 'YYYY-MM-DD')",
+                f"{d} <= SYSDATE",
+                f"TRUNC({d}) = {d}",
+            ]
+        if num and dat:
+            pool.append(f"{q(num.name)} < 100 OR {q(dat.name)} IS NULL")
+        long_col = table.column({"LONG", "LONG RAW"})
+        if long_col:
+            pool.append(f"{q(long_col.name)} IS NOT NULL OR 1 = 1")
+        for k, condition in enumerate(rng.sample(pool, min(len(pool), 2))):
+            cname = self.unique(f"CK_{table.name}_{k}"[:120])
+            self.add(
+                "constraints.csv",
+                OWNER,
+                cname,
+                table.name,
+                "C",
+                "ENABLED",
+                None,
+                None,
+                None,
+            )
+            roll = rng.random()
+            if roll < 0.06:
+                self.add("check_conditions.csv", OWNER, cname, condition[:8], 1)
+            elif roll < 0.10:
+                pass  # a check with no condition row at all
+            else:
+                self.add("check_conditions.csv", OWNER, cname, condition, 0)
+
+    def add_indexes(self, table: Table) -> None:
+        rng = self.rng
+        plain_cols = [
+            c
+            for c in table.columns
+            if c.data_type not in LOBS | {"LONG", "LONG RAW", "BFILE"}
+        ]
+        if not plain_cols:
+            return
+        for k in range(rng.randint(0, 3)):
+            roll = rng.random()
+            if roll < 0.05:
+                iname = table.name  # collides with its own table
+            elif roll < 0.09 and self.sequences:
+                iname = rng.choice(self.sequences)
+            else:
+                iname = self.unique(f"IX_{table.name}_{k}"[:120])
+            itype = rng.choices(
+                [
+                    "NORMAL",
+                    "NORMAL",
+                    "NORMAL",
+                    "BITMAP",
+                    "FUNCTION-BASED NORMAL",
+                    "DOMAIN",
+                    "NORMAL/REV",
+                ],
+                weights=[40, 20, 10, 10, 15, 3, 2],
+            )[0]
+            unique = "UNIQUE" if rng.random() < 0.2 else "NONUNIQUE"
+            status = "UNUSABLE" if rng.random() < 0.05 else "VALID"
+            self.add(
+                "indexes.csv", OWNER, iname, table.name, itype, unique, status, "N", "1"
+            )
+            self.obj(iname, "INDEX")
+            if rng.random() < 0.03:
+                continue  # an index with no column facts at all
+            cols = rng.sample(plain_cols, min(len(plain_cols), rng.randint(1, 3)))
+            for pos, c in enumerate(cols, start=1):
+                if itype == "FUNCTION-BASED NORMAL" and pos == 1:
+                    expr = rng.choice(
+                        [
+                            f"UPPER({q(c.name)})",
+                            f"NVL({q(c.name)}, 0)",
+                            f"SYS_OP_MAP_NONNULL({q(c.name)})",
+                            f"{q(c.name)} DESC",
+                            f"TRUNC({q(c.name)})",
+                        ]
+                    )
+                    self.add(
+                        "index_columns.csv", OWNER, iname, f"SYS_NC0000{pos}$", pos
+                    )
+                    self.add(
+                        "index_expressions.csv",
+                        OWNER,
+                        iname,
+                        pos,
+                        expr[:6] if rng.random() < 0.1 else expr,
+                        1 if rng.random() < 0.1 else 0,
+                    )
+                else:
+                    self.add("index_columns.csv", OWNER, iname, c.name, pos)
+            if table.partitioned or rng.random() < 0.05:
+                self.add(
+                    "part_indexes.csv",
+                    OWNER,
+                    iname,
+                    table.name,
+                    rng.choice(["LOCAL", "GLOBAL"]),
+                )
+
+    def add_partitioning(self, table: Table) -> None:
+        rng = self.rng
+        name = table.name
+        dat, num, txt = table.dated(), table.numeric(), table.textual()
+        kinds = []
+        if dat:
+            kinds.append("RANGE_DATE")
+        if num:
+            kinds += ["RANGE_NUM", "HASH"]
+        if txt:
+            kinds.append("LIST")
+        kinds += ["REFERENCE", "SYSTEM"] if rng.random() < 0.12 else []
+        if not kinds:
+            return
+        kind = rng.choice(kinds)
+        table.partitioned = True
+        self.rows["tables.csv"][-1][4] = "YES"
+        parts: list[tuple[str, str | None, int]] = []
+        interval = None
+        sub = "NONE"
+        key: list[str] = []
+        if kind == "RANGE_DATE" and dat:
+            ptype = "RANGE"
+            key = [dat.name]
+            for k, year in enumerate((2023, 2024, 2025), start=1):
+                parts.append(
+                    (
+                        f"P_{k}",
+                        f"TO_DATE(' {year}-01-01 00:00:00', 'SYYYY-MM-DD"
+                        " HH24:MI:SS', 'NLS_CALENDAR=GREGORIAN')",
+                        0,
+                    )
+                )
+            if rng.random() < 0.5:
+                parts.append(("P_MAX", "MAXVALUE", 0))
+            elif rng.random() < 0.4:
+                interval = "NUMTOYMINTERVAL(1, 'MONTH')"
+        elif kind == "RANGE_NUM" and num:
+            ptype = "RANGE"
+            key = [num.name]
+            parts = [
+                ("P_LOW", "100", 0),
+                ("P_MID", "1000", 0),
+                ("P_HIGH", "MAXVALUE", 0),
+            ]
+            if rng.random() < 0.15 and len(table.columns) > 2:
+                other = table.columns[1 if table.columns[1] is not num else 0]
+                key.append(other.name)
+                parts = [("P_A", "100, 'X'", 0), ("P_B", "MAXVALUE, MAXVALUE", 0)]
+        elif kind == "LIST" and txt:
+            ptype = "LIST"
+            key = [txt.name]
+            parts = [("P_AB", "'A', 'B'", 0), ("P_C", "'O''Brien', 'C'", 0)]
+            parts.append(("P_REST", rng.choice(["DEFAULT", "NULL", "'Z', NULL"]), 0))
+        elif kind == "HASH" and num:
+            ptype = "HASH"
+            key = [num.name]
+            parts = [(f"SYS_P{100 + k}", None, 0) for k in range(4)]
+        elif kind == "REFERENCE":
+            ptype = "REFERENCE"
+            parts = [("P_REF_1", None, 0), ("P_REF_2", None, 0)]
+        else:
+            ptype = "SYSTEM"
+            parts = [("P_SYS_1", None, 0), ("P_SYS_2", None, 0)]
+        if parts and rng.random() < 0.08:
+            pname, high, _ = parts[-1]
+            parts[-1] = (pname, (high or "")[:10], 1)
+        if ptype in ("RANGE", "LIST") and rng.random() < 0.3:
+            sub = "HASH" if num else "LIST"
+            subkey = num.name if num else (txt.name if txt else key[0])
+            self.add("part_subkey_columns.csv", OWNER, name, subkey, 1)
+            for pname, _, _ in parts:
+                for s in range(2):
+                    high = None if sub == "HASH" else ("'S1'" if s == 0 else "DEFAULT")
+                    self.add(
+                        "part_subpartitions.csv",
+                        OWNER,
+                        name,
+                        pname,
+                        f"{pname}_SP{s + 1}",
+                        s + 1,
+                        high,
+                        0,
+                    )
+        count = 1048575 if interval else len(parts)
+        self.add("part_tables.csv", OWNER, name, ptype, sub, count, interval)
+        for pos, col in enumerate(key, start=1):
+            self.add("part_key_columns.csv", OWNER, name, col, pos)
+        for pos, (pname, high, truncated) in enumerate(parts, start=1):
+            self.add("part_partitions.csv", OWNER, name, pname, pos, high, truncated)
+        if key:
+            spec = ", ".join(q(c) for c in key)
+            table.partition_clause = f"\n  PARTITION BY {ptype} ({spec})\n (PARTITION "
+            table.partition_clause += ", PARTITION ".join(
+                f"{q(p)} VALUES LESS THAN ({h})" if h else q(p) for p, h, _ in parts
+            )
+            table.partition_clause += ")"
+
+    # -- everything else -------------------------------------------------
+
+    def make_sequences(self) -> None:
+        rng = self.rng
+        for i in range(max(2, len(self.tables) // 3)):
+            name = self.unique(self.styled_name("SEQ", i, allow_reserved=False))
+            self.sequences.append(name)
+            self.obj(name, "SEQUENCE")
+            shape = rng.random()
+            if shape < 0.55:
+                row = ("1", "9" * 28, "1", "N", "20", str(rng.randrange(1, 10**6)))
+            elif shape < 0.70:
+                row = ("1", "999999", "1", "Y", "0", "17")
+            elif shape < 0.80:
+                row = ("-1000", "-1", "-1", "N", "20", "-5")
+            elif shape < 0.88:
+                row = ("1", "9" * 28, "1", "N", "20", "9" * 20)
+            elif shape < 0.94:
+                row = ("1", "100", "1", "N", "20", "500")
+            else:
+                row = ("1", "1.5E+28", "1", "N", "20", "abc")
+            self.add("sequences.csv", OWNER, name, *row)
+            self.ddl["ddl_sequences.sql"].append(
+                f"-- PGRECON_OBJECT SEQUENCE {OWNER}.{name}\n\n"
+                f"   CREATE SEQUENCE  {q(OWNER)}.{q(name)}  MINVALUE {row[0]}"
+                f" MAXVALUE {row[1]} INCREMENT BY {row[2]} START WITH {row[5]}"
+                f" CACHE 20 NOORDER  {'CYCLE' if row[3] == 'Y' else 'NOCYCLE'} ;\n"
+            )
+            self.add_grants(name, "SEQUENCE")
+
+    def make_colliding_sequence(self) -> None:
+        if self.tables and self.rng.random() < 0.15:
+            name = self.rng.choice(self.tables).name
+            self.sequences.append(name)
+            self.obj(name, "SEQUENCE")
+            self.add("sequences.csv", OWNER, name, "1", "9" * 28, "1", "N", "20", "7")
+
+    def make_views(self) -> None:
+        rng = self.rng
+        tables = [t for t in self.tables if t.columns]
+        for i in range(max(2, len(tables) // 3)):
+            base = rng.choice(tables)
+            roll = rng.random()
+            if roll < 0.05:
+                name = rng.choice(tables).name  # collides with a table
+            else:
+                name = self.unique(self.styled_name("V", i, allow_reserved=False))
+            cols, body, deps = self.view_body(base)
+            header = ", ".join(q(c) for c in cols)
+            self.views.append((name, cols))
+            self.obj(name, "VIEW")
+            self.ddl["ddl_views.sql"].append(
+                f"-- PGRECON_OBJECT VIEW {OWNER}.{name}\n\n"
+                f"  CREATE OR REPLACE FORCE EDITIONABLE VIEW {q(OWNER)}.{q(name)}"
+                f" ({header}) AS\n  {body};\n"
+            )
+            for dep_name, dep_type in deps:
+                self.add(
+                    "dependencies.csv", OWNER, name, "VIEW", OWNER, dep_name, dep_type
+                )
+            self.add_grants(name, "VIEW")
+
+    def view_body(self, base: Table) -> tuple[list[str], str, list[tuple[str, str]]]:
+        rng = self.rng
+        t = q(base.name)
+        c1 = base.columns[0]
+        c2 = base.columns[-1]
+        num, txt, dat = base.numeric(), base.textual(), base.dated()
+        deps = [(base.name, "TABLE")]
+        roll = rng.random()
+        if roll < 0.25:
+            return (
+                [c1.name, c2.name],
+                f"SELECT {q(c1.name)}, {q(c2.name)}\n  FROM {t}\n"
+                f" WHERE {q(c1.name)} IS NOT NULL",
+                deps,
+            )
+        if roll < 0.40 and num and txt:
+            return (
+                [txt.name, "CNT", "TOTAL"],
+                f"SELECT {q(txt.name)}, COUNT(*) AS CNT, SUM(NVL({q(num.name)}, 0))"
+                f" AS TOTAL\n  FROM {t}\n GROUP BY {q(txt.name)}",
+                deps,
+            )
+        if roll < 0.50 and len(self.tables) > 1:
+            other = rng.choice(self.tables)
+            deps.append((other.name, "TABLE"))
+            o1 = other.columns[0]
+            return (
+                ["A_COL", "B_COL"],
+                f"SELECT a.{q(c1.name)} AS A_COL, b.{q(o1.name)} AS B_COL\n"
+                f"  FROM {t} a, {q(other.name)} b\n"
+                f" WHERE a.{q(c1.name)} = b.{q(o1.name)} (+)",
+                deps,
+            )
+        if roll < 0.58:
+            return (
+                [c1.name, "LVL"],
+                f"SELECT {q(c1.name)}, LEVEL AS LVL\n  FROM {t}\n"
+                f" START WITH {q(c2.name)} IS NULL\n"
+                f" CONNECT BY PRIOR {q(c1.name)} = {q(c2.name)}",
+                deps,
+            )
+        if roll < 0.66:
+            return (
+                [c1.name],
+                f"SELECT {q(c1.name)}\n  FROM (SELECT {q(c1.name)} FROM {t}"
+                f" ORDER BY {q(c1.name)})\n WHERE ROWNUM <= 10",
+                deps,
+            )
+        if roll < 0.76 and self.views:
+            vname, vcols = rng.choice(self.views)
+            deps = [(vname, "VIEW")]
+            return (
+                vcols,
+                f"SELECT {', '.join(q(c) for c in vcols)}\n  FROM {q(vname)}\n"
+                f" WHERE {q(vcols[0])} IS NOT NULL",
+                deps,
+            )
+        if roll < 0.84 and txt and dat:
+            return (
+                ["ST", "YM"],
+                f"SELECT DECODE({q(txt.name)}, 'A', 'Active', 'Other') AS ST,"
+                f" TO_CHAR({q(dat.name)}, 'YYYY-MM') AS YM\n  FROM {t}",
+                deps,
+            )
+        if roll < 0.90:
+            return ["X"], "SELECT FROM WHERE (((", []
+        if roll < 0.95 and txt and num:
+            return (
+                ["A", "B"],
+                f"SELECT * FROM (SELECT {q(txt.name)} AS K, {q(num.name)} AS V"
+                f" FROM {t})\n PIVOT (SUM(V) FOR K IN ('A' AS A, 'B' AS B))",
+                deps,
+            )
+        return (
+            [c.name for c in base.columns],
+            f"SELECT {', '.join(q(c.name) for c in base.columns)}\n  FROM {t}"
+            " WITH READ ONLY",
+            deps,
+        )
+
+    def make_mviews(self) -> None:
+        rng = self.rng
+        candidates = [t for t in self.tables if t.numeric() and t.textual()]
+        for i in range(rng.randint(0, 2)):
+            if not candidates:
+                return
+            base = rng.choice(candidates)
+            num, txt = base.numeric(), base.textual()
+            assert num is not None and txt is not None
+            name = self.unique(f"MV_{base.name}_{i}"[:120])
+            self.obj(name, "MATERIALIZED VIEW")
+            self.obj(name, "TABLE")
+            if rng.random() < 0.3:
+                query = (
+                    f"SELECT {q(txt.name)}, COUNT(*) AS HEADCOUNT, 0 AS TOTAL"
+                    f" FROM {q(OWNER)}.NOPE"
+                )
+            else:
+                query = (
+                    f"SELECT {q(txt.name)}, COUNT(*) AS HEADCOUNT,"
+                    f" SUM({q(num.name)}) AS TOTAL\n  FROM {q(base.name)}\n"
+                    f" GROUP BY {q(txt.name)}"
+                )
+            self.add(
+                "mviews.csv",
+                OWNER,
+                name,
+                rng.choice(["Y", "N"]),
+                rng.choice(["COMPLETE", "FAST", "FORCE"]),
+                query,
+            )
+            self.add("tables.csv", OWNER, name, 12, 40, "NO", "N", "         1")
+            for pos, (col, dtype) in enumerate(
+                ((txt.name, txt), ("HEADCOUNT", None), ("TOTAL", None)), start=1
+            ):
+                self.add(
+                    "columns.csv",
+                    OWNER,
+                    name,
+                    col,
+                    pos,
+                    dtype.data_type if dtype else "NUMBER",
+                    dtype.length if dtype else 22,
+                    dtype.precision if dtype else None,
+                    dtype.scale if dtype else None,
+                    "Y",
+                )
+            iname = f"I_SNAP$_{name}"[:120]
+            self.add(
+                "indexes.csv",
+                OWNER,
+                iname,
+                name,
+                "FUNCTION-BASED NORMAL",
+                "UNIQUE",
+                "VALID",
+                "N",
+                "1",
+            )
+            self.obj(iname, "INDEX")
+            self.add("index_columns.csv", OWNER, iname, "SYS_NC00004$", 1)
+            self.add(
+                "index_expressions.csv",
+                OWNER,
+                iname,
+                1,
+                f"SYS_OP_MAP_NONNULL({q(txt.name)})",
+                0,
+            )
+            self.add(
+                "dependencies.csv",
+                OWNER,
+                name,
+                "MATERIALIZED VIEW",
+                OWNER,
+                base.name,
+                "TABLE",
+            )
+
+    def make_links_and_synonyms(self) -> None:
+        rng = self.rng
+        links = []
+        for i in range(rng.randint(1, 2)):
+            name = rng.choice([f"LINK_{i}", f"LINK_{i}.WORLD", f"REMOTE{i}"])
+            links.append(name)
+            self.obj(name, "DATABASE LINK")
+            self.add(
+                "db_links.csv",
+                OWNER,
+                name,
+                rng.choice(["REMOTE_USER", "APP", None]),
+                rng.choice([f"//host{i}:1521/SVC", "svc'quoted", "TNSALIAS", None]),
+            )
+        targets = [(t.name, "TABLE") for t in self.tables] + [
+            (v, "VIEW") for v, _ in self.views
+        ]
+        for i in range(rng.randint(3, 6)):
+            roll = rng.random()
+            owner = "PUBLIC" if roll < 0.15 else OWNER
+            if roll < 0.05 and self.tables:
+                name = rng.choice(self.tables).name
+            else:
+                name = self.unique(self.styled_name("SYN", i, allow_reserved=False))
+            if owner == OWNER:
+                self.obj(name, "SYNONYM")
+            target, _ = rng.choice(targets)
+            link = None
+            if rng.random() < 0.15:
+                target, link = "REMOTE_TABLE", rng.choice(links)
+            elif rng.random() < 0.1:
+                target = "DOES_NOT_EXIST"
+            self.add("synonyms.csv", owner, name, OWNER, target, link)
+
+    # -- stored code -----------------------------------------------------
+
+    def unit(
+        self, name: str, otype: str, text: str, deps: list[tuple[str, str]]
+    ) -> None:
+        self.obj(name, otype)
+        for line_no, line in enumerate(text.split("\n"), start=1):
+            self.add("source.csv", OWNER, name, otype, line_no, line + "\n")
+        for dep_name, dep_type in deps:
+            self.add("dependencies.csv", OWNER, name, otype, OWNER, dep_name, dep_type)
+
+    def ref(self, name: str) -> str:
+        if name.isidentifier() and name.isupper() and name not in RESERVED:
+            return name
+        return q(name)
+
+    def make_code(self) -> None:
+        rng = self.rng
+        tables = [t for t in self.tables if t.pk and t.numeric() and t.textual()]
+        if not tables:
+            return
+        funcs: list[str] = []
+        for i in range(rng.randint(4, 8)):
+            t = rng.choice(tables)
+            pk = self.ref(t.pk_cols[0])
+            tbl = self.ref(t.name)
+            num = t.numeric()
+            txt = t.textual()
+            assert num is not None and txt is not None
+            ncol, tcol = self.ref(num.name), self.ref(txt.name)
+            fname = f"F_{rng.choice(TABLE_WORDS)}_{i}"
+            if rng.random() < 0.08:
+                fname = f"myFunc{i}"
+            deps = [(t.name, "TABLE")]
+            shape = rng.random()
+            if shape < 0.18:
+                body = (
+                    f"FUNCTION {self.ref(fname)}(p_id IN NUMBER) RETURN NUMBER IS\n"
+                    "  l_count NUMBER := 0;\nBEGIN\n"
+                    f"  SELECT COUNT(*) INTO l_count FROM {tbl} WHERE {pk} = p_id;\n"
+                    "  RETURN NVL(l_count, 0);\n"
+                    f"END {self.ref(fname)};"
+                )
+            elif shape < 0.30:
+                body = (
+                    f"FUNCTION {fname}(p_v IN VARCHAR2) RETURN VARCHAR2 IS\nBEGIN\n"
+                    "  IF p_v IS NULL THEN\n    RETURN 'none';\n"
+                    "  ELSIF LENGTH(p_v) > 10 THEN\n    RETURN SUBSTR(p_v, 1, 10);\n"
+                    "  ELSE\n    RETURN UPPER(p_v);\n  END IF;\nEND;"
+                )
+                deps = []
+            elif shape < 0.42:
+                body = (
+                    f"FUNCTION {fname} RETURN NUMBER IS\n  l_total NUMBER := 0;\n"
+                    f"BEGIN\n  FOR r IN (SELECT {ncol} FROM {tbl}) LOOP\n"
+                    f"    l_total := l_total + NVL(r.{ncol}, 0);\n  END LOOP;\n"
+                    "  RETURN l_total;\nEND;"
+                )
+            elif shape < 0.52:
+                body = (
+                    f"FUNCTION {fname}(p_id IN NUMBER) RETURN VARCHAR2 IS\n"
+                    "  l_v VARCHAR2(4000);\nBEGIN\n"
+                    f"  SELECT {tcol} INTO l_v FROM {tbl} WHERE {pk} = p_id;\n"
+                    "  RETURN l_v;\nEXCEPTION\n  WHEN NO_DATA_FOUND THEN\n"
+                    "    RETURN NULL;\nEND;"
+                )
+            elif shape < 0.60:
+                body = (
+                    f"FUNCTION {fname}(p_id IN NUMBER) RETURN NUMBER IS\n"
+                    "  PRAGMA AUTONOMOUS_TRANSACTION;\nBEGIN\n"
+                    f"  UPDATE {tbl} SET {ncol} = {ncol} + 1 WHERE {pk} = p_id;\n"
+                    "  COMMIT;\n  RETURN SQL%ROWCOUNT;\nEND;"
+                )
+            elif shape < 0.66:
+                body = (
+                    f"FUNCTION {fname}(p_t IN VARCHAR2) RETURN NUMBER IS\nBEGIN\n"
+                    "  EXECUTE IMMEDIATE 'TRUNCATE TABLE ' || p_t;\n  RETURN 1;\nEND;"
+                )
+                deps = []
+            elif shape < 0.72:
+                body = (
+                    f"FUNCTION {fname} RETURN NUMBER IS\n"
+                    "  TYPE t_ids IS TABLE OF NUMBER;\n  l_ids t_ids;\nBEGIN\n"
+                    f"  SELECT {pk} BULK COLLECT INTO l_ids FROM {tbl};\n"
+                    "  RETURN l_ids.COUNT;\nEND;"
+                )
+            elif shape < 0.78:
+                body = (
+                    f"FUNCTION {fname} RETURN VARCHAR2 IS\nBEGIN\n"
+                    "  RETURN SYS_CONTEXT('USERENV', 'SESSION_USER');\nEND;"
+                )
+                deps = []
+            elif shape < 0.84 and funcs:
+                callee = rng.choice(funcs)
+                body = (
+                    f"FUNCTION {fname}(p_id IN NUMBER) RETURN NUMBER IS\nBEGIN\n"
+                    f"  RETURN {self.ref(callee)}(p_id) * 2;\nEND;"
+                )
+                deps = [(callee, "FUNCTION")]
+            elif shape < 0.90:
+                body = (
+                    f"FUNCTION {fname}(p_id IN NUMBER) RETURN NUMBER IS\nBEGIN\n"
+                    "  REMOTE_PKG.LOG_IT@SALES_LINK(p_id);\n  RETURN 0;\nEND;"
+                )
+                deps = []
+            elif shape < 0.95:
+                body = f"FUNCTION {fname} RETURN NUMBER IS\nBEGIN\n  RETURN 1 +;\nEND;"
+                deps = []
+            else:
+                body = (
+                    f"FUNCTION {fname}(p_id IN NUMBER) RETURN {tbl}%ROWTYPE IS\n"
+                    f"  l_row {tbl}%ROWTYPE;\nBEGIN\n"
+                    f"  SELECT * INTO l_row FROM {tbl}"
+                    f" WHERE {pk} = p_id AND ROWNUM = 1;\n"
+                    "  DBMS_OUTPUT.PUT_LINE('found');\n  RETURN l_row;\nEND;"
+                )
+            body = body.replace(f"FUNCTION {fname}", f"FUNCTION {self.ref(fname)}", 1)
+            funcs.append(fname)
+            self.routines.append((fname, "FUNCTION"))
+            self.unit(fname, "FUNCTION", body, deps)
+
+        for i in range(rng.randint(2, 4)):
+            t = rng.choice(tables)
+            pk = self.ref(t.pk_cols[0])
+            tbl = self.ref(t.name)
+            txt = t.textual()
+            assert txt is not None
+            tcol = self.ref(txt.name)
+            pname = f"P_{rng.choice(TABLE_WORDS)}_{i}"
+            deps = [(t.name, "TABLE")]
+            shape = rng.random()
+            if shape < 0.3 and self.sequences:
+                seq = rng.choice(self.sequences)
+                body = (
+                    f"PROCEDURE {pname}(p_name IN VARCHAR2) IS\nBEGIN\n"
+                    f"  INSERT INTO {tbl} ({pk}, {tcol})"
+                    f" VALUES ({self.ref(seq)}.NEXTVAL, p_name);\nEND;"
+                )
+                deps.append((seq, "SEQUENCE"))
+            elif shape < 0.55:
+                body = (
+                    f"PROCEDURE {pname}(p_id IN NUMBER, p_name IN VARCHAR2) IS\n"
+                    f"BEGIN\n  UPDATE {tbl} SET {tcol} = p_name WHERE {pk} = p_id;\n"
+                    "  IF SQL%ROWCOUNT = 0 THEN\n"
+                    "    RAISE_APPLICATION_ERROR(-20001, 'no such row');\n"
+                    "  END IF;\nEND;"
+                )
+            elif shape < 0.75:
+                body = (
+                    f"PROCEDURE {pname}(p_id IN NUMBER, p_out OUT VARCHAR2) IS\n"
+                    f"BEGIN\n  SELECT {tcol} INTO p_out FROM {tbl} WHERE {pk} = p_id;\n"
+                    "  IF p_out = '' THEN\n    p_out := 'empty';\n  END IF;\nEND;"
+                )
+            elif shape < 0.9 and funcs:
+                callee = rng.choice(funcs)
+                body = (
+                    f"PROCEDURE {pname}(p_id IN NUMBER) IS\n  l NUMBER;\nBEGIN\n"
+                    f"  l := {self.ref(callee)}(p_id);\n  COMMIT;\nEND;"
+                )
+                deps = [(callee, "FUNCTION")]
+            else:
+                body = (
+                    f"PROCEDURE {pname} IS\n  l_f UTL_FILE.FILE_TYPE;\nBEGIN\n"
+                    "  l_f := UTL_FILE.FOPEN('DIR', 'x.txt', 'w');\n"
+                    "  UTL_FILE.PUT_LINE(l_f, 'hello');\n  UTL_FILE.FCLOSE(l_f);\nEND;"
+                )
+                deps = []
+            self.routines.append((pname, "PROCEDURE"))
+            self.unit(pname, "PROCEDURE", body, deps)
+
+        for i in range(rng.randint(1, 2)):
+            pkg = f"PKG_{rng.choice(TABLE_WORDS)}_{i}"
+            self.packages.append(pkg)
+            spec = (
+                f"PACKAGE {pkg} AS\n  g_count NUMBER := 0;\n"
+                "  PROCEDURE bump(p_by IN NUMBER);\n"
+                "  FUNCTION current_count RETURN NUMBER;\nEND;"
+            )
+            self.unit(pkg, "PACKAGE", spec, [])
+            t = rng.choice(tables)
+            body = (
+                f"PACKAGE BODY {pkg} AS\n  PROCEDURE bump(p_by IN NUMBER) IS\n"
+                "  BEGIN\n    g_count := g_count + p_by;\n"
+                f"    UPDATE {self.ref(t.name)} SET {self.ref(t.pk_cols[0])} ="
+                f" {self.ref(t.pk_cols[0])} WHERE 1 = 0;\n  END;\n"
+                "  FUNCTION current_count RETURN NUMBER IS\n  BEGIN\n"
+                "    RETURN g_count;\n  END;\nBEGIN\n  g_count := 1;\nEND;"
+            )
+            if rng.random() < 0.15:
+                body = f"PACKAGE BODY {pkg} wrapped\na000000\n369\nabcd\nabcd\n1\n2 :e:"
+            self.unit(pkg, "PACKAGE BODY", body, [(t.name, "TABLE")])
+
+        if rng.random() < 0.5:
+            self.unit(
+                "ADDR_T",
+                "TYPE",
+                "TYPE ADDR_T AS OBJECT (\n  street VARCHAR2(100),\n"
+                "  city VARCHAR2(50),\n  MEMBER FUNCTION label RETURN VARCHAR2\n);",
+                [],
+            )
+            if rng.random() < 0.5:
+                self.unit(
+                    "ADDR_T",
+                    "TYPE BODY",
+                    "TYPE BODY ADDR_T AS\n  MEMBER FUNCTION label RETURN VARCHAR2 IS\n"
+                    "  BEGIN\n    RETURN street || ', ' || city;\n  END;\nEND;",
+                    [],
+                )
+
+        if rng.random() < 0.4:
+            job = f"JOB_{rng.choice(TABLE_WORDS)}"
+            self.obj(job, "JOB")
+
+        self.make_triggers(tables)
+
+    def make_triggers(self, tables: list[Table]) -> None:
+        rng = self.rng
+        for i in range(rng.randint(2, 5)):
+            t = rng.choice(tables)
+            tbl = self.ref(t.name)
+            pk = self.ref(t.pk_cols[0])
+            dat = t.dated()
+            num = t.numeric()
+            assert num is not None
+            ncol = self.ref(num.name)
+            name = self.unique(f"TRG_{t.name}_{i}"[:120])
+            status = "DISABLED" if rng.random() < 0.1 else "ENABLED"
+            shape = rng.random()
+            deps = [(t.name, "TABLE")]
+            if shape < 0.25 and dat:
+                ttype, event = "BEFORE EACH ROW", "INSERT"
+                body = (
+                    f"TRIGGER {name}\n  BEFORE INSERT ON {tbl}\n  FOR EACH ROW\n"
+                    f"BEGIN\n  :NEW.{self.ref(dat.name)} := SYSDATE;\nEND;"
+                )
+            elif shape < 0.45 and self.sequences:
+                seq = self.ref(rng.choice(self.sequences))
+                ttype, event = "BEFORE EACH ROW", "INSERT OR UPDATE"
+                body = (
+                    f"TRIGGER {name}\n  BEFORE INSERT OR UPDATE ON {tbl}\n"
+                    "  FOR EACH ROW\nBEGIN\n"
+                    f"  IF :NEW.{pk} IS NULL THEN\n"
+                    f"    SELECT {seq}.NEXTVAL INTO :NEW.{pk} FROM dual;\n"
+                    "  END IF;\nEND;"
+                )
+            elif shape < 0.60:
+                other = rng.choice(tables)
+                ttype, event = "AFTER STATEMENT", "INSERT OR UPDATE OR DELETE"
+                body = (
+                    f"TRIGGER {name}\n  AFTER INSERT OR UPDATE OR DELETE ON {tbl}\n"
+                    f"BEGIN\n  UPDATE {self.ref(other.name)} SET"
+                    f" {self.ref(other.pk_cols[0])} = {self.ref(other.pk_cols[0])}"
+                    " WHERE 1 = 0;\nEND;"
+                )
+                deps.append((other.name, "TABLE"))
+            elif shape < 0.72:
+                ttype, event = "AFTER EACH ROW", "UPDATE"
+                body = (
+                    f"TRIGGER {name}\n  AFTER UPDATE ON {tbl}\n  FOR EACH ROW\n"
+                    f"  WHEN (NEW.{ncol} > 100)\nBEGIN\n"
+                    f"  IF :OLD.{ncol} <> :NEW.{ncol} THEN\n    NULL;\n  END IF;\nEND;"
+                )
+            elif shape < 0.82:
+                ttype, event = "COMPOUND", "INSERT"
+                body = (
+                    f"TRIGGER {name}\n  FOR INSERT ON {tbl}\n  COMPOUND TRIGGER\n"
+                    "  BEFORE STATEMENT IS\n  BEGIN\n    NULL;\n"
+                    "  END BEFORE STATEMENT;\n"
+                    "  AFTER EACH ROW IS\n  BEGIN\n    NULL;\n  END AFTER EACH ROW;\n"
+                    "END;"
+                )
+            elif shape < 0.90:
+                ttype, event = "AFTER EACH ROW", "DELETE"
+                body = (
+                    f"TRIGGER {name}\n  AFTER DELETE ON {tbl}\n  FOR EACH ROW\n"
+                    "DECLARE\n  PRAGMA AUTONOMOUS_TRANSACTION;\nBEGIN\n"
+                    f"  INSERT INTO {tbl} ({pk}) VALUES (:OLD.{pk});\n  COMMIT;\nEND;"
+                )
+            elif shape < 0.95 and self.views:
+                vname, vcols = rng.choice(self.views)
+                ttype, event = "INSTEAD OF", "INSERT"
+                body = (
+                    f"TRIGGER {name}\n  INSTEAD OF INSERT ON {self.ref(vname)}\n"
+                    f"  FOR EACH ROW\nBEGIN\n  INSERT INTO {tbl} ({pk})"
+                    f" VALUES (:NEW.{self.ref(vcols[0])});\nEND;"
+                )
+                deps = [(vname, "VIEW"), (t.name, "TABLE")]
+                self.add("triggers.csv", OWNER, name, ttype, event, vname, status)
+                self.unit(name, "TRIGGER", body, deps)
+                continue
+            else:
+                ttype, event = "BEFORE EACH ROW", "INSERT"
+                body = (
+                    f"TRIGGER {name}\n  BEFORE INSERT ON GONE_TABLE\n  FOR EACH ROW\n"
+                    "BEGIN\n  NULL;\nEND;"
+                )
+                deps = []
+                self.add(
+                    "triggers.csv", OWNER, name, ttype, event, "GONE_TABLE", status
+                )
+                self.unit(name, "TRIGGER", body, deps)
+                continue
+            self.add("triggers.csv", OWNER, name, ttype, event, t.name, status)
+            self.unit(name, "TRIGGER", body, deps)
+
+    # -- environment -----------------------------------------------------
+
+    def add_grants(self, name: str, kind: str) -> None:
+        rng = self.rng
+        if rng.random() > 0.5:
+            return
+        privileges = {
+            "TABLE": [
+                "SELECT",
+                "INSERT",
+                "UPDATE",
+                "DELETE",
+                "REFERENCES",
+                "ALTER",
+                "INDEX",
+                "FLASHBACK",
+                "DEBUG",
+                "READ",
+                "ON COMMIT REFRESH",
+                "QUERY REWRITE",
+            ],
+            "VIEW": ["SELECT", "READ", "DEBUG"],
+            "SEQUENCE": ["SELECT", "ALTER"],
+        }[kind]
+        grantees = ["APP_RO", "APP_RW", "PUBLIC", "app_reader", "REPORTING ROLE"]
+        for privilege in rng.sample(
+            privileges, min(len(privileges), rng.randint(1, 3))
+        ):
+            self.add(
+                "grants.csv",
+                rng.choice(grantees),
+                OWNER,
+                name,
+                privilege,
+                "YES" if rng.random() < 0.15 else "NO",
+            )
+
+    def make_environment(self) -> None:
+        rng = self.rng
+        product, version = rng.choice(VERSIONS)
+        self.add("meta.csv", "schema", OWNER)
+        self.add("meta.csv", "extracted_at", STAMP)
+        self.add("meta.csv", "product", product)
+        self.add("meta.csv", "version", version)
+        self.add("nls.csv", "NLS_CHARACTERSET", rng.choice(CHARSETS))
+        self.add("nls.csv", "NLS_LANGUAGE", "AMERICAN")
+        self.add("nls.csv", "NLS_NCHAR_CHARACTERSET", "AL16UTF16")
+        self.add("nls.csv", "NLS_TERRITORY", "AMERICA")
+        self.add("license.csv", "banner", product.strip() + " Release " + version)
+        self.add("license.csv", "cpu_count", str(rng.choice([2, 8, 64])))
+        for feature, detail in FEATURES:
+            self.add("features.csv", feature, detail, rng.choice([0, 0, 1, 3]))
+        for feature in (
+            "Partitioning",
+            "Advanced Compression",
+            "Real Application Security",
+        ):
+            self.add(
+                "feature_usage.csv",
+                feature,
+                version,
+                rng.choice([0, 5]),
+                rng.choice(["TRUE", "FALSE"]),
+                None,
+            )
+        if rng.random() < 0.3:
+            self.add("plan_management.csv", "SQL_PLAN_BASELINE", "SQL_PLAN_1", "YES")
+        self.add("grants.csv", "PUBLIC", OWNER, OWNER, "INHERIT PRIVILEGES", "NO")
+        if rng.random() < 0.3:
+            self.add("grants.csv", "APP_RO", OWNER, "NOT_IN_DUMP", "SELECT", "NO")
+
+    # -- output ----------------------------------------------------------
+
+    def build(self) -> None:
+        self.make_sequences()
+        self.make_tables()
+        self.make_colliding_sequence()
+        self.make_views()
+        self.make_mviews()
+        self.make_links_and_synonyms()
+        self.make_code()
+        self.make_environment()
+
+    def write(self, out: Path) -> Manifest:
+        out.mkdir(parents=True, exist_ok=True)
+        for spool, header in HEADERS.items():
+            with (out / spool).open("w", encoding="utf-8", newline="") as fh:
+                fh.write("\n")
+                writer = csv.writer(
+                    fh, quoting=csv.QUOTE_NONNUMERIC, lineterminator="\n"
+                )
+                writer.writerow(header)
+                writer.writerows(self.rows[spool])
+        for name, chunks in self.ddl.items():
+            (out / name).write_text(
+                "\n" + "\n".join(chunks), encoding="utf-8", newline="\n"
+            )
+        manifest = Manifest(self.seed, list(self.objects))
+        self.corrupt(out, manifest)
+        (out / "fuzz_manifest.json").write_text(manifest.as_json(), encoding="ascii")
+        return manifest
+
+    def corrupt(self, out: Path, manifest: Manifest) -> None:
+        """Hostile spools: what real client dumps actually contain."""
+        rng = self.rng
+        if rng.random() < 0.35:
+            spool = rng.choice(
+                [
+                    "grants.csv",
+                    "plan_management.csv",
+                    "check_conditions.csv",
+                    "column_defaults.csv",
+                    "index_expressions.csv",
+                    "feature_usage.csv",
+                ]
+            )
+            (out / spool).write_text(ERROR_SPOOL, encoding="utf-8", newline="\n")
+            manifest.error_spools.append(spool)
+        if rng.random() < 0.25:
+            spool = rng.choice(["table_comments.csv", "column_comments.csv"])
+            path = out / spool
+            text = path.read_text(encoding="utf-8")
+            hangul = "\uc9c1\uc6d0 \uba85\ub2e8 \ubcf4\uace0\uc11c"
+            while True:
+                data = (text + hangul).encode("cp949", errors="replace")
+                try:
+                    data.decode("utf-8")
+                except UnicodeDecodeError:
+                    break
+                hangul += "\ud55c\uae00"
+            path.write_bytes(data)
+            manifest.lossy_spools.append(spool)
+        if rng.random() < 0.25:
+            spool = rng.choice(["columns.csv", "source.csv", "index_columns.csv"])
+            path = out / spool
+            data = path.read_bytes()
+            path.write_bytes(data[: max(len(data) - 37, 0)])
+            manifest.torn_spools.append(spool)
+        if rng.random() < 0.2:
+            spool = rng.choice(
+                [
+                    "part_partitions.csv",
+                    "index_expressions.csv",
+                    "column_defaults.csv",
+                    "constraint_columns.csv",
+                    "dependencies.csv",
+                ]
+            )
+            (out / spool).unlink()
+            manifest.missing_spools.append(spool)
+
+
+def generate(seed: int, out: Path) -> Manifest:
+    estate = Estate(seed)
+    estate.build()
+    return estate.write(out)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("out", type=Path)
+    parser.add_argument("--seed", type=int, default=1)
+    args = parser.parse_args()
+    manifest = generate(args.seed, args.out)
+    print(f"seed {args.seed}: {len(manifest.objects)} objects in {args.out}")
+    for label, spools in (
+        ("error spools", manifest.error_spools),
+        ("foreign code page", manifest.lossy_spools),
+        ("torn", manifest.torn_spools),
+        ("missing", manifest.missing_spools),
+    ):
+        if spools:
+            print(f"  {label}: {', '.join(spools)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -720,15 +720,18 @@ class Estate:
         if dtype in NUMERIC:
             pool = ["0 ", "1.5 ", "-1 ", "NULL "]
         elif dtype in TEXTUAL:
-            pool = [
-                "'N' ",
-                "USER ",
-                "'O''Brien' ",
-                "TO_CHAR(SYSDATE, 'YYYY') ",
-                "SYS_CONTEXT('USERENV', 'SESSION_USER') ",
-                "sys_guid() ",
-                "NULL ",
-            ]
+            # Sized to the column: Oracle accepts an oversized default at
+            # CREATE and fails the row; that is not the shape to fuzz.
+            width = (c.length or 0) // (2 if dtype.startswith("N") else 1)
+            pool = ["'N' ", "NULL "]
+            if width >= 8:
+                pool += ["'O''Brien' ", "TO_CHAR(SYSDATE, 'YYYY') "]
+            if width >= 32:
+                pool += [
+                    "USER ",
+                    "SYS_CONTEXT('USERENV', 'SESSION_USER') ",
+                    "sys_guid() ",
+                ]
         elif dtype == "DATE" or dtype.startswith("TIMESTAMP"):
             pool = [
                 "SYSDATE ",
@@ -841,13 +844,26 @@ class Estate:
             )
             self.add("constraint_columns.csv", OWNER, cname, col, 1)
 
-    def fk_column(self, table: Table, tag: str) -> str:
+    def fk_column(self, table: Table, tag: str, like: Column | None = None) -> str:
+        """A referencing column, typed like the referenced one, as
+        Oracle requires."""
         base = f"{tag}_ID"
         existing = {c.name for c in table.columns}
         name = base
         while name in existing:
             name = f"{base}_{self.rng.randrange(1, 99)}"
-        col = Column(name, "NUMBER", 22, 10, 0, True, "NUMBER(10,0)")
+        if like is None:
+            col = Column(name, "NUMBER", 22, 10, 0, True, "NUMBER(10,0)")
+        else:
+            col = Column(
+                name,
+                like.data_type,
+                like.length,
+                like.precision,
+                like.scale,
+                True,
+                like.ddl,
+            )
         table.columns.append(col)
         self.add(
             "columns.csv",
@@ -855,10 +871,10 @@ class Estate:
             table.name,
             name,
             len(table.columns),
-            "NUMBER",
-            22,
-            10,
-            0,
+            col.data_type,
+            col.length,
+            col.precision,
+            col.scale,
             "Y",
         )
         return name
@@ -874,7 +890,8 @@ class Estate:
         rng = self.rng
         tag = "PARENT" if self_ref else parent.name[:12].replace(" ", "_")
         cname = self.unique(f"FK_{table.name}_{tag}"[:120])
-        cols = [self.fk_column(table, tag) for _ in ref_cols]
+        by_name = {c.name: c for c in parent.columns}
+        cols = [self.fk_column(table, tag, by_name.get(ref)) for ref in ref_cols]
         if rng.random() < 0.05:
             # Column count that does not match the referenced key.
             cols.append(self.fk_column(table, tag + "_X"))
@@ -1794,10 +1811,24 @@ class Estate:
         return manifest
 
     def corrupt(self, out: Path, manifest: Manifest) -> None:
-        """Hostile spools: what real client dumps actually contain."""
+        """Hostile spools: what real client dumps actually contain.
+
+        Each spool suffers at most one fate, so the runner's expectation
+        for it stays well defined.
+        """
         rng = self.rng
+        touched: set[str] = set()
+
+        def pick(candidates: list[str]) -> str | None:
+            free = [c for c in candidates if c not in touched]
+            if not free:
+                return None
+            chosen = rng.choice(free)
+            touched.add(chosen)
+            return chosen
+
         if rng.random() < 0.35:
-            spool = rng.choice(
+            spool = pick(
                 [
                     "grants.csv",
                     "plan_management.csv",
@@ -1807,30 +1838,33 @@ class Estate:
                     "feature_usage.csv",
                 ]
             )
-            (out / spool).write_text(ERROR_SPOOL, encoding="utf-8", newline="\n")
-            manifest.error_spools.append(spool)
+            if spool:
+                (out / spool).write_text(ERROR_SPOOL, encoding="utf-8", newline="\n")
+                manifest.error_spools.append(spool)
         if rng.random() < 0.25:
-            spool = rng.choice(["table_comments.csv", "column_comments.csv"])
-            path = out / spool
-            text = path.read_text(encoding="utf-8")
-            hangul = "\uc9c1\uc6d0 \uba85\ub2e8 \ubcf4\uace0\uc11c"
-            while True:
-                data = (text + hangul).encode("cp949", errors="replace")
-                try:
-                    data.decode("utf-8")
-                except UnicodeDecodeError:
-                    break
-                hangul += "\ud55c\uae00"
-            path.write_bytes(data)
-            manifest.lossy_spools.append(spool)
+            spool = pick(["table_comments.csv", "column_comments.csv"])
+            if spool:
+                path = out / spool
+                text = path.read_text(encoding="utf-8")
+                hangul = "\uc9c1\uc6d0 \uba85\ub2e8 \ubcf4\uace0\uc11c"
+                while True:
+                    data = (text + hangul).encode("cp949", errors="replace")
+                    try:
+                        data.decode("utf-8")
+                    except UnicodeDecodeError:
+                        break
+                    hangul += "\ud55c\uae00"
+                path.write_bytes(data)
+                manifest.lossy_spools.append(spool)
         if rng.random() < 0.25:
-            spool = rng.choice(["columns.csv", "source.csv", "index_columns.csv"])
-            path = out / spool
-            data = path.read_bytes()
-            path.write_bytes(data[: max(len(data) - 37, 0)])
-            manifest.torn_spools.append(spool)
+            spool = pick(["columns.csv", "source.csv", "index_columns.csv"])
+            if spool:
+                path = out / spool
+                data = path.read_bytes()
+                path.write_bytes(data[: max(len(data) - 37, 0)])
+                manifest.torn_spools.append(spool)
         if rng.random() < 0.2:
-            spool = rng.choice(
+            spool = pick(
                 [
                     "part_partitions.csv",
                     "index_expressions.csv",
@@ -1839,8 +1873,9 @@ class Estate:
                     "dependencies.csv",
                 ]
             )
-            (out / spool).unlink()
-            manifest.missing_spools.append(spool)
+            if spool:
+                (out / spool).unlink()
+                manifest.missing_spools.append(spool)
 
 
 def generate(seed: int, out: Path) -> Manifest:

--- a/tools/fuzz_run.py
+++ b/tools/fuzz_run.py
@@ -227,8 +227,14 @@ def apply_live(conninfo: str, seed: int, sql_path: Path) -> str | None:
         text=True,
     )
     if proc.returncode != 0:
-        lines = [line for line in proc.stderr.strip().splitlines() if line.strip()]
-        return " | ".join(lines[-3:]) if lines else "psql failed without a message"
+        # Truncation notices are expected and noisy; the error and its
+        # detail lines are what a reader needs.
+        lines = [
+            line.strip()
+            for line in proc.stderr.splitlines()
+            if line.strip() and "NOTICE:" not in line
+        ]
+        return " | ".join(lines[-4:]) if lines else "psql failed without a message"
     return None
 
 

--- a/tools/fuzz_run.py
+++ b/tools/fuzz_run.py
@@ -1,0 +1,369 @@
+"""Drive adversarial dumps through the pipeline and check the two laws.
+
+For every seed: generate the dump (tools/fuzz_dump.py), load it, run
+the rule engine, convert, and then check what the converter promises:
+
+  never crashes    load, report, and convert complete on every input;
+  never loses      every object the loader stored is either created in
+                   the emitted DDL or named in the residue - nothing
+                   vanishes between the inventory and the output;
+  degrades visibly a spool carrying an Oracle error or a foreign code
+                   page leaves a warning row in the inventory;
+  applies          with --pg, the DDL applies to a live PostgreSQL with
+                   check_function_bodies on and zero rejected statements.
+
+    uv run python tools/fuzz_run.py --seeds 20
+    uv run python tools/fuzz_run.py --seeds 5 --start 100 \
+        --pg "host=127.0.0.1 user=postgres password=ci"
+
+Every failure prints its seed; the dump, DDL, and residue of a failing
+seed stay under the work directory for reproduction.
+"""
+
+import argparse
+import importlib.util
+import logging
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType
+
+from pgrecon.convert import convert_schema, residue_report
+from pgrecon.convert.identifiers import ident
+from pgrecon.convert.residue import Residue
+from pgrecon.inventory import load_dump
+from pgrecon.rules.engine import run_rules
+
+HERE = Path(__file__).resolve().parent
+
+
+def generator() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("fuzz_dump", HERE / "fuzz_dump.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# A PostgreSQL identifier as the converter writes it: folded and bare,
+# or double-quoted with doubled inner quotes.
+_IDENT = r'("(?:[^"]|"")+"|[^\s(;]+)'
+_CREATED = {
+    "table": re.compile(r"^CREATE TABLE " + _IDENT, re.MULTILINE),
+    "view": re.compile(r"^CREATE (?:OR REPLACE )?VIEW " + _IDENT, re.MULTILINE),
+    "mview": re.compile(r"^CREATE MATERIALIZED VIEW " + _IDENT, re.MULTILINE),
+    "sequence": re.compile(r"^CREATE SEQUENCE " + _IDENT, re.MULTILINE),
+    "index": re.compile(r"^CREATE (?:UNIQUE )?INDEX " + _IDENT, re.MULTILINE),
+    "constraint": re.compile(r"ADD CONSTRAINT " + _IDENT),
+    "routine": re.compile(
+        r"^CREATE OR REPLACE (?:FUNCTION|PROCEDURE) " + _IDENT, re.MULTILINE
+    ),
+    "trigger": re.compile(r"^CREATE TRIGGER " + _IDENT, re.MULTILINE),
+}
+
+
+@dataclass
+class SeedResult:
+    seed: int
+    objects: int = 0
+    findings: int = 0
+    residue: int = 0
+    ddl_bytes: int = 0
+    seconds: float = 0.0
+    failures: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+def _bare(token: str) -> str:
+    if token.startswith('"'):
+        return token[1:-1].replace('""', '"').lower()
+    return token.lower()
+
+
+def universe(conn: sqlite3.Connection) -> list[tuple[str, str]]:
+    """Every inventory object the converter is answerable for."""
+    items: list[tuple[str, str]] = []
+    mviews = {r[0] for r in conn.execute("SELECT mview_name FROM mviews")}
+    for (name,) in conn.execute("SELECT table_name FROM tables"):
+        if name not in mviews:
+            items.append(("table", name))
+    items += [("mview", name) for name in sorted(mviews)]
+    for otype, kind in (
+        ("VIEW", "view"),
+        ("FUNCTION", "routine"),
+        ("PROCEDURE", "routine"),
+        ("PACKAGE", "package"),
+        ("TYPE", "type"),
+    ):
+        items += [
+            (kind, r[0])
+            for r in conn.execute("SELECT name FROM objects WHERE type = ?", (otype,))
+        ]
+    items += [
+        ("sequence", r[0]) for r in conn.execute("SELECT sequence_name FROM sequences")
+    ]
+    items += [
+        ("synonym", r[0]) for r in conn.execute("SELECT synonym_name FROM synonyms")
+    ]
+    items += [("dblink", r[0]) for r in conn.execute("SELECT db_link FROM db_links")]
+    items += [
+        ("trigger", r[0]) for r in conn.execute("SELECT trigger_name FROM triggers")
+    ]
+    # Key-backing and generated indexes are the constraints' business;
+    # LOB segment indexes are storage.
+    items += [
+        ("index", r[0])
+        for r in conn.execute(
+            "SELECT i.index_name FROM indexes i"
+            " WHERE COALESCE(i.generated, 'N') <> 'Y'"
+            " AND COALESCE(i.index_type, '') <> 'LOB'"
+            " AND NOT EXISTS (SELECT 1 FROM constraints c"
+            "   WHERE c.owner = i.owner AND c.constraint_name = i.index_name)"
+        )
+    ]
+    # NOT NULL checks live on the column; every other constraint must
+    # come out the other side by name.
+    not_null = re.compile(r'^"?[A-Za-z0-9_$#]+"?\s+IS\s+NOT\s+NULL$', re.IGNORECASE)
+    for name, ctype, condition in conn.execute(
+        "SELECT c.constraint_name, c.type, k.condition FROM constraints c"
+        " LEFT JOIN check_conditions k"
+        " ON k.owner = c.owner AND k.constraint_name = c.constraint_name"
+    ):
+        if ctype == "C" and condition is not None:
+            stripped = condition.strip()
+            if not stripped or not_null.match(stripped):
+                continue
+        if ctype in ("P", "U", "R", "C"):
+            items.append(("constraint", name))
+    return items
+
+
+def unaccounted(
+    conn: sqlite3.Connection, sql: str, residue: tuple[Residue, ...]
+) -> list[str]:
+    created: dict[str, set[str]] = {
+        kind: {m.group(1) for m in pattern.finditer(sql)}
+        for kind, pattern in _CREATED.items()
+    }
+    bare = {kind: {_bare(t) for t in tokens} for kind, tokens in created.items()}
+    named: dict[str, set[str]] = {}
+    for r in residue:
+        named.setdefault(r.object_name, set()).add(r.kind)
+
+    lost = []
+    for kind, name in universe(conn):
+        variants = [ident(name)]
+        if kind in ("table", "view", "mview"):
+            variants.append(ident(name.lower()))
+        if kind == "index":
+            variants.append(ident(name + "_IX"))
+        if kind == "constraint":
+            variants += [ident(name + "_PK"), ident(name + "_UK")]
+        kinds = named.get(name, set())
+        created_kind = "view" if kind == "synonym" else kind
+        if created_kind in created and any(
+            v in created[created_kind] for v in variants
+        ):
+            continue
+        if kind in ("routine", "trigger") and name.lower() in bare[kind]:
+            continue
+        if kind == "dblink" and kinds:
+            continue
+        if kind == "index" and name.upper().startswith("I_SNAP$") and kinds:
+            continue
+        if kinds - {"note"}:
+            continue
+        lost.append(f"{kind} {name}")
+    return lost
+
+
+def apply_live(conninfo: str, seed: int, sql_path: Path) -> str | None:
+    """Apply the DDL to a fresh database; return the first error, if any."""
+    dbname = f"fuzz_{seed}"
+    admin = re.sub(r"\bdbname=\S+", "", conninfo).strip()
+    setup = subprocess.run(
+        [
+            "psql",
+            f"{admin} dbname=postgres",
+            "-qX",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-c",
+            f"DROP DATABASE IF EXISTS {dbname}",
+            "-c",
+            f"CREATE DATABASE {dbname}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if setup.returncode != 0:
+        return "could not create the scratch database: " + setup.stderr.strip()
+    proc = subprocess.run(
+        [
+            "psql",
+            f"{admin} dbname={dbname}",
+            "-qX",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-c",
+            "SET check_function_bodies = on",
+            "-f",
+            str(sql_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["psql", f"{admin} dbname=postgres", "-qX", "-c", f"DROP DATABASE {dbname}"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        lines = [line for line in proc.stderr.strip().splitlines() if line.strip()]
+        return " | ".join(lines[-3:]) if lines else "psql failed without a message"
+    return None
+
+
+def check_seed(
+    seed: int, work: Path, pg: str | None, gen: ModuleType | None = None
+) -> SeedResult:
+    gen = gen or generator()
+    started = time.perf_counter()
+    result = SeedResult(seed)
+    dump = work / f"seed-{seed}"
+    if dump.exists():
+        shutil.rmtree(dump)
+    manifest = gen.generate(seed, dump)
+    db = work / f"seed-{seed}.db"
+
+    try:
+        load_dump(dump, db)
+    except Exception as exc:
+        result.failures.append(f"load crashed: {exc!r}")
+        result.seconds = time.perf_counter() - started
+        return result
+
+    conn = sqlite3.connect(db)
+    try:
+        have = set(conn.execute("SELECT owner, name, type FROM objects"))
+        result.objects = len(have)
+        missing = [tuple(o) for o in manifest.objects if tuple(o) not in have]
+        if missing:
+            result.failures.append(
+                f"{len(missing)} generated objects never reached the inventory,"
+                f" first {missing[0]}"
+            )
+        meta = dict(conn.execute("SELECT key, value FROM meta"))
+        for spool in manifest.error_spools:
+            if f"load_warning:{spool[:-4]}" not in meta:
+                result.failures.append(
+                    f"{spool} carried an Oracle error but no load_warning row"
+                    " was left for it"
+                )
+        for spool in manifest.lossy_spools:
+            if f"encoding_warning:{spool}" not in meta:
+                result.failures.append(
+                    f"{spool} was in a foreign code page but no encoding_warning"
+                    " row was left"
+                )
+
+        try:
+            result.findings = len(run_rules(db))
+        except Exception as exc:
+            result.failures.append(f"report crashed: {exc!r}")
+
+        try:
+            conversion = convert_schema(db)
+            report = residue_report(conversion.residue)
+        except Exception as exc:
+            result.failures.append(f"convert crashed: {exc!r}")
+            result.seconds = time.perf_counter() - started
+            return result
+        sql_path = dump / "schema_pg.sql"
+        sql_path.write_text(conversion.sql, encoding="utf-8", newline="\n")
+        (dump / "residue.txt").write_text(report, encoding="utf-8", newline="\n")
+        result.residue = len(conversion.residue)
+        result.ddl_bytes = len(conversion.sql.encode("utf-8"))
+
+        lost = unaccounted(conn, conversion.sql, conversion.residue)
+        if lost:
+            shown = ", ".join(lost[:4])
+            more = f" and {len(lost) - 4} more" if len(lost) > 4 else ""
+            result.failures.append(
+                f"{len(lost)} objects neither created nor in the residue: {shown}{more}"
+            )
+    finally:
+        conn.close()
+
+    if pg and result.ok:
+        error = apply_live(pg, seed, sql_path)
+        if error:
+            result.failures.append(f"DDL rejected by PostgreSQL: {error}")
+
+    result.seconds = time.perf_counter() - started
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--seeds", type=int, default=10, help="how many seeds")
+    parser.add_argument("--start", type=int, default=1, help="first seed")
+    parser.add_argument(
+        "--pg",
+        help="libpq conninfo (key=value form) of a PostgreSQL to apply the DDL to",
+    )
+    parser.add_argument("--work", type=Path, default=Path("fuzz-work"))
+    parser.add_argument(
+        "--keep", action="store_true", help="keep the dumps of passing seeds too"
+    )
+    args = parser.parse_args()
+    args.work.mkdir(parents=True, exist_ok=True)
+    # Names in the dumps are deliberately not ASCII; Windows consoles
+    # are deliberately not UTF-8.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    logging.getLogger("sqlglot").setLevel(logging.ERROR)
+    logging.getLogger("pgrecon").setLevel(logging.ERROR)
+    gen = generator()
+
+    failed: list[SeedResult] = []
+    for seed in range(args.start, args.start + args.seeds):
+        result = check_seed(seed, args.work, args.pg, gen)
+        status = "ok " if result.ok else "FAIL"
+        print(
+            f"seed {seed:>8} {status} {result.objects:>4} objects"
+            f" {result.findings:>4} findings {result.residue:>4} residue"
+            f" {result.ddl_bytes:>7} bytes DDL {result.seconds:5.1f}s",
+            flush=True,
+        )
+        for failure in result.failures:
+            print(f"    - {failure}", flush=True)
+        if not result.ok:
+            failed.append(result)
+        elif not args.keep:
+            shutil.rmtree(args.work / f"seed-{seed}", ignore_errors=True)
+            (args.work / f"seed-{seed}.db").unlink(missing_ok=True)
+    print()
+    if failed:
+        seeds = ", ".join(str(r.seed) for r in failed)
+        print(f"{len(failed)} of {args.seeds} seeds failed: {seeds}")
+        print(
+            "reproduce one with:"
+            f" uv run python tools/fuzz_dump.py --seed {failed[0].seed}"
+            f" {args.work / f'seed-{failed[0].seed}'}"
+        )
+        return 1
+    print(f"all {args.seeds} seeds obeyed the laws")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of the 0.7 consolidation train: the schema fuzzer, and the fixes from its first run.

**Fuzzer.** `tools/fuzz_dump.py` generates an adversarial extraction dump from a seed (names past 63 bytes in ASCII and Hangul, cross-kind name collisions, reserved words as columns, every catalog data type, every partition layout, 28-digit sequence bounds, views over views, convertible and refusable stored code, spools carrying an Oracle error / a foreign code page / a torn last row). `tools/fuzz_run.py` drives seeds through load, report, convert and checks the laws: never crashes; never loses silently (every inventory object is created in the DDL or named in the residue); degrades visibly (hostile spools leave warning rows); applies (with `--pg`, zero rejected statements on live PostgreSQL). New nightly workflow `fuzz.yml` runs a fresh seed window against PostgreSQL 16 and 18 and also runs 12 fixed seeds on PRs touching the converter, loader, or fuzzer. `tests/test_fuzz.py` runs three fixed seeds in the suite.

**What it found (fixed here):**
- check constraints whose condition never reached the inventory vanished through an inner join; views without DDL and routines without source vanished too. All three are declined by name now.
- the loader's `PGRECON_OBJECT` marker did not match names with spaces or commas.
- materialized views with case-sensitive names refused every time ("no column facts") because their columns were looked up under an uppercased name.
- emitters disagreed on identifier spelling: tables kept a quoted name's case while comments, grants, views, and checks lowercased it, so `"MixedDept"` or a column named `LIMIT` produced DDL referencing a relation or column that does not exist. One rule now (`fold_case`): names Oracle stored uppercase fold to lowercase, names created quoted keep their case, reserved words are quoted lowercase; the sqlglot identifier fold uses the same rule. Trigger names and their tables are quoted when needed; the trigger function takes a plain derived name.

Locally: full suite green, 40 fresh seeds obey the laws without PostgreSQL. The live-apply law runs for the first time in this PR's fuzz job; expect iteration on what it finds.