### PR TITLE
convert: fold ROWNUM top-N into LIMIT and carry MERGE over in routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
   partitioned tables themselves; a view over one table that names a
   column the converted table does not have declines instead of
   shipping a query PostgreSQL rejects.
+- The code lane converts two more Oracle idioms instead of refusing
+  them. A ROWNUM bound that is a plain conjunct of a SELECT's WHERE
+  becomes LIMIT on that query - the SELECT ... WHERE ... AND ROWNUM = 1
+  lookup and the sorted-subquery top-N; ROWNUM beside ORDER BY, GROUP
+  BY, DISTINCT, an aggregate, or a set operation in the same query,
+  under OR, or in DELETE and UPDATE, declines with the reason. MERGE
+  statements carry over: an action's trailing WHERE moves onto its WHEN
+  clause as AND (...), SET t.col loses the alias PostgreSQL rejects,
+  and USING dual becomes a one-row source; WHEN MATCHED ... DELETE
+  declines by name.
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/README.md
+++ b/README.md
@@ -186,11 +186,17 @@ equivalent PL/pgSQL form - comments and formatting carried through,
 SELECT INTO made STRICT so NO_DATA_FOUND still raises, function
 bodies left to PostgreSQL's own validation rather than disabling it.
 
+Inside those routines the top-N idiom converts - a ROWNUM bound over
+a sorted subquery becomes LIMIT - and MERGE carries over with its
+action conditions moved onto the WHEN clauses, the SET aliases
+dropped, and USING dual made a one-row source.
+
 The second file is the residue: one line per declined object, naming
-the construct and the line number. Packages, triggers, CONNECT BY,
-autonomous transactions, REF CURSOR interfaces, BULK COLLECT - the
-work that needs a person is refused by name, never guessed at, and a
-routine that calls a refused routine is refused with it.
+the construct and the line number. Packages, CONNECT BY, autonomous
+transactions, REF CURSOR interfaces, BULK COLLECT, ROWNUM beside an
+ORDER BY - the work that needs a person is refused by name, never
+guessed at, and a routine that calls a refused routine is refused
+with it.
 
 Two rules hold everywhere. Nothing invalid ships: CI applies the
 bundled sample's conversion to live PostgreSQL 16, 17, and 18 on

--- a/src/pgrecon/convert/code.py
+++ b/src/pgrecon/convert/code.py
@@ -23,8 +23,6 @@ _REFUSE_FEATURES = {
     "connect_by": "CONNECT BY becomes a WITH RECURSIVE query",
     "outer_join_plus": "(+) outer joins in embedded SQL need the ANSI form",
     "goto": "GOTO has no counterpart; restructure the control flow",
-    "merge": "MERGE clauses differ between the engines; port it by hand",
-    "rownum": "ROWNUM needs LIMIT or row_number(); rewrite the query",
     "rowid": "ROWID access paths do not exist; use the primary key",
     "decode_call": ("DECODE matches NULLs; rewrite as CASE with IS NOT DISTINCT FROM"),
     "sql_cursor_attribute": (

--- a/src/pgrecon/convert/plsql_rewrite.py
+++ b/src/pgrecon/convert/plsql_rewrite.py
@@ -82,6 +82,12 @@ class _Rewriter(PlSqlParserListener):  # type: ignore[misc]
         # Loop variables of cursor FOR loops, which Oracle declares by
         # itself and PL/pgSQL wants declared as records.
         self.records: list[str] = []
+        # MERGE action conditions to move onto their WHEN clause at
+        # assembly: (matched start, stop, where start, stop, condition
+        # start, stop).
+        self.merge_moves: list[tuple[int, int, int, int, int, int]] = []
+        # Statement terminators that already carry a LIMIT.
+        self.limited: set[int] = set()
         self.reasons: list[str] = []
         self.notes: list[str] = []
         self.suppressed: list[tuple[int, int]] = []
@@ -208,6 +214,55 @@ class _Rewriter(PlSqlParserListener):  # type: ignore[misc]
             name = _fold_written(self._span_text(record))
             if name not in self.records:
                 self.records.append(name)
+
+    # -- MERGE ------------------------------------------------------
+
+    def enterMerge_update_clause(self, ctx: Any) -> None:
+        if ctx.merge_update_delete_part() is not None:
+            self._reason(
+                ctx,
+                "MERGE ... WHEN MATCHED ... DELETE has no PostgreSQL form;"
+                " express the delete as a second WHEN MATCHED clause by hand",
+            )
+            return
+        self._merge_condition(ctx)
+
+    def enterMerge_insert_clause(self, ctx: Any) -> None:
+        self._merge_condition(ctx)
+
+    def _merge_condition(self, ctx: Any) -> None:
+        """Oracle filters a MERGE action with a trailing WHERE; PostgreSQL
+        puts the condition on the WHEN. The move happens at assembly so
+        the condition keeps every token rewrite made inside it."""
+        where = ctx.where_clause()
+        if where is None:
+            return
+        condition = where.condition()
+        matched = ctx.MATCHED()
+        if condition is None or matched is None:
+            self._reason(
+                ctx, "the MERGE action's WHERE did not dissect; port it by hand"
+            )
+            return
+        self.merge_moves.append(
+            (
+                matched.symbol.start,
+                matched.symbol.stop,
+                where.start.start,
+                where.stop.stop,
+                condition.start.start,
+                condition.stop.stop,
+            )
+        )
+
+    def enterMerge_element(self, ctx: Any) -> None:
+        # SET t.col = ... on Oracle; PostgreSQL wants the bare column.
+        column = ctx.column_name()
+        if column is None:
+            return
+        written = self._span_text(column)
+        if "." in written:
+            self._edit_ctx(column, _fold_written(written.rsplit(".", 1)[1]))
 
     # -- declarations -----------------------------------------------
 
@@ -594,6 +649,194 @@ def _q_literal(text: str) -> str | None:
     return "'" + text[3:-2].replace("'", "''") + "'"
 
 
+_AGGREGATES = {"COUNT", "SUM", "MIN", "MAX", "AVG", "LISTAGG", "STDDEV", "VARIANCE"}
+_ROWNUM_BREAKERS = {
+    L.ORDER: "ORDER BY",
+    L.GROUP: "GROUP BY",
+    L.HAVING: "HAVING",
+    L.UNION: "UNION",
+    L.INTERSECT: "INTERSECT",
+    L.MINUS: "MINUS",
+    L.CONNECT: "CONNECT BY",
+    L.START: "START WITH",
+}
+_ROWNUM_GENERIC = (
+    "ROWNUM outside a plain top-N bound needs LIMIT or row_number(); rewrite by hand"
+)
+
+
+def _fold_rownum(rewriter: _Rewriter, tokens: list[Any]) -> None:
+    """Every ROWNUM either becomes a LIMIT or names its refusal."""
+    for i, tok in enumerate(tokens):
+        if tok.type == L.ROWNUM:
+            reason = _rownum_to_limit(rewriter, tokens, i)
+            if reason is not None:
+                rewriter.reasons.append(f"{reason} (line {tok.line})")
+
+
+def _rownum_to_limit(rewriter: _Rewriter, tokens: list[Any], i: int) -> str | None:
+    """Turn the top-N idiom into LIMIT on its query, or say why not.
+
+    The shape that converts: ROWNUM compared with an integer literal,
+    as a plain conjunct of a SELECT's WHERE, with no ORDER BY, GROUP
+    BY, set operation, DISTINCT, or aggregate in that same query -
+    Oracle numbers rows before all of those, so LIMIT would mean
+    something else. The bound is removed from the WHERE and LIMIT n
+    goes at the end of that query, ahead of any FOR UPDATE.
+    """
+    j = i + 1
+    if j >= len(tokens):
+        return _ROWNUM_GENERIC
+    op = tokens[j]
+    if op.type == L.LESS_THAN_OP:
+        kind = "lt"
+        if (
+            j + 1 < len(tokens)
+            and tokens[j + 1].type == L.EQUALS_OP
+            and tokens[j + 1].start == op.stop + 1
+        ):
+            kind = "lte"
+            j += 1
+    elif op.type == L.EQUALS_OP:
+        kind = "eq"
+    else:
+        return _ROWNUM_GENERIC
+    if j + 1 >= len(tokens) or tokens[j + 1].type != L.UNSIGNED_INTEGER:
+        return _ROWNUM_GENERIC
+    num = tokens[j + 1]
+    bound = int(num.text or "0")
+    if kind == "lt":
+        bound -= 1
+    if kind == "eq" and bound != 1:
+        return (
+            "ROWNUM = n above 1 never matches a row on Oracle; rewrite the query"
+            " by hand"
+        )
+    if bound < 1:
+        return _ROWNUM_GENERIC
+    prev = tokens[i - 1] if i > 0 else None
+    if prev is None or prev.type not in (L.WHERE, L.AND):
+        return _ROWNUM_GENERIC
+
+    # The query this WHERE belongs to, walking left at depth 0.
+    depth = 0
+    k = i - 1
+    where_at = select_at = None
+    while k >= 0:
+        t = tokens[k]
+        if t.type == L.RIGHT_PAREN:
+            depth += 1
+        elif t.type == L.LEFT_PAREN:
+            if depth == 0:
+                return "ROWNUM inside a parenthesized condition needs a rewrite by hand"
+            depth -= 1
+        elif depth == 0:
+            if t.type == L.WHERE and where_at is None:
+                where_at = k
+            elif where_at is not None and t.type == L.SELECT:
+                select_at = k
+                break
+            elif where_at is not None and t.type in (L.DELETE, L.UPDATE):
+                return (
+                    "ROWNUM in DELETE or UPDATE has no LIMIT on PostgreSQL; bound"
+                    " the rows through the key in a subquery by hand"
+                )
+            elif t.type in (L.SEMICOLON, L.BEGIN, L.LOOP, L.THEN, L.ELSE):
+                break
+            elif where_at is not None and t.type == L.OR:
+                return "ROWNUM under OR needs a rewrite by hand"
+        k -= 1
+    if select_at is None or where_at is None:
+        return _ROWNUM_GENERIC
+
+    # The select list: no DISTINCT, no aggregate ahead of the bound.
+    depth = 0
+    for k in range(select_at + 1, where_at):
+        t = tokens[k]
+        if t.type == L.LEFT_PAREN:
+            depth += 1
+        elif t.type == L.RIGHT_PAREN:
+            depth -= 1
+        elif depth == 0:
+            if k == select_at + 1 and t.type in (L.DISTINCT, L.UNIQUE):
+                return "ROWNUM with DISTINCT is not a top-N bound; rewrite by hand"
+            if t.type == L.FROM:
+                break
+            nxt = tokens[k + 1] if k + 1 < len(tokens) else None
+            if (
+                (t.text or "").upper() in _AGGREGATES
+                and nxt is not None
+                and nxt.type == L.LEFT_PAREN
+            ):
+                return (
+                    "ROWNUM ahead of an aggregate bounds the rows counted, which"
+                    " LIMIT does not; rewrite by hand"
+                )
+
+    # The rest of the query, walking right at depth 0 to its end.
+    depth = 0
+    m = j + 2
+    terminator = None
+    while m < len(tokens):
+        t = tokens[m]
+        if t.type == L.LEFT_PAREN:
+            depth += 1
+        elif t.type == L.RIGHT_PAREN:
+            if depth == 0:
+                terminator = m
+                break
+            depth -= 1
+        elif depth == 0:
+            if t.type in (L.SEMICOLON, L.FOR):
+                terminator = m
+                break
+            if t.type in _ROWNUM_BREAKERS:
+                return (
+                    f"ROWNUM beside {_ROWNUM_BREAKERS[t.type]} in the same query"
+                    " is not a top-N bound on Oracle either; sort or group in a"
+                    " subquery, then bound, by hand"
+                )
+            if t.type == L.OR:
+                return "ROWNUM under OR needs a rewrite by hand"
+        m += 1
+    if terminator is None:
+        return _ROWNUM_GENERIC
+    if terminator in rewriter.limited:
+        return "ROWNUM bounded twice in one query; rewrite by hand"
+    rewriter.limited.add(terminator)
+
+    following = tokens[j + 2]
+    if prev.type == L.WHERE and following.type == L.AND:
+        rewriter._edit(tokens[i].start, following.stop, "")
+    else:
+        rewriter._edit(prev.start, num.stop, "")
+    term = tokens[terminator]
+    if term.type == L.FOR:
+        rewriter._edit(term.start, term.stop, f"LIMIT {bound} FOR")
+    else:
+        rewriter._edit(term.start, term.stop, f" LIMIT {bound}{term.text}")
+    return None
+
+
+def _merge_moves(text: str, rewriter: _Rewriter) -> list[tuple[int, int, str]]:
+    """Move each MERGE action's trailing WHERE onto its WHEN clause,
+    carrying the token rewrites made inside the condition along."""
+    edits = list(rewriter.edits)
+    for m_start, m_stop, w_start, w_stop, c_start, c_stop in rewriter.merge_moves:
+        inner = [e for e in edits if c_start <= e[0] and e[1] <= c_stop]
+        edits = [e for e in edits if e not in inner]
+        shifted = [(s - c_start, e - c_start, r) for s, e, r in inner]
+        folded = _apply(text[c_start : c_stop + 1], shifted)
+        if folded is None:
+            rewriter.reasons.append(
+                "MERGE condition rewrites collided; port it by hand"
+            )
+            return edits
+        edits.append((w_start, w_stop, ""))
+        edits.append((m_start, m_stop, f"MATCHED AND ({folded.strip()})"))
+    return edits
+
+
 def _scan_tokens(rewriter: _Rewriter, stream: Any) -> None:
     """Function-level rewrites off the default token channel.
 
@@ -605,6 +848,7 @@ def _scan_tokens(rewriter: _Rewriter, stream: Any) -> None:
     """
     tokens = [t for t in stream.tokens if t.channel == 0]
     folded_literals = _fold_binds(rewriter, tokens)
+    _fold_rownum(rewriter, tokens)
     for i, tok in enumerate(tokens):
         nxt = tokens[i + 1] if i + 1 < len(tokens) else None
         prev = tokens[i - 1] if i > 0 else None
@@ -619,6 +863,14 @@ def _scan_tokens(rewriter: _Rewriter, stream: Any) -> None:
             and (after is None or after.type != L.PERIOD)
         ):
             rewriter._edit(tok.start, nxt.stop, "")
+        elif (
+            tok.type == L.USING
+            and nxt is not None
+            and (nxt.text or "").upper() == "DUAL"
+        ):
+            # MERGE ... USING dual: a one-row source PostgreSQL lacks.
+            alias = " AS dual" if after is None or after.type == L.ON else ""
+            rewriter._edit(nxt.start, nxt.stop, "(SELECT 1)" + alias)
         elif tok.type == L.CHAR_STRING:
             if tok.start not in folded_literals:
                 standard = _q_literal(tok.text or "")
@@ -742,10 +994,11 @@ def rewrite_unit(
     )
     ParseTreeWalker.DEFAULT.walk(rewriter, parse.tree)
     _scan_tokens(rewriter, parse.tokens)
+    edits = _merge_moves(full, rewriter)
     notes = tuple(dict.fromkeys(rewriter.notes))
     if rewriter.reasons:
         return RewriteResult(None, tuple(dict.fromkeys(rewriter.reasons)), notes)
-    edited = _apply(full, rewriter.edits)
+    edited = _apply(full, edits)
     if edited is None or _BODY_OPEN not in edited:
         # Overlapping edits, or a shape with no IS/AS body such as an
         # external call specification: refuse rather than guess.

--- a/src/pgrecon/convert/plsql_rewrite.py
+++ b/src/pgrecon/convert/plsql_rewrite.py
@@ -16,7 +16,7 @@ from typing import Any
 from antlr4 import ParseTreeWalker
 from antlr4.tree.Tree import TerminalNode
 
-from pgrecon.convert.identifiers import _PLAIN_IDENT, _RESERVED, ident
+from pgrecon.convert.identifiers import ident
 from pgrecon.convert.typemap import map_code_type
 from pgrecon.plsql import parse_source
 from pgrecon.plsql._generated.PlSqlLexer import PlSqlLexer as L
@@ -51,16 +51,14 @@ def _fold_written(name: str) -> str:
     """A name as written in source, folded the way ident() folds.
 
     Generated DDL writes '"ADD_DATA"'; the converted schema knows that
-    object as add_data. Anything not plainly foldable stays verbatim.
+    object as add_data, and '"RATE WITH SPACE"' as "rate with space".
+    A quoted name carrying lowercase letters was case-sensitive on
+    Oracle and stays verbatim, as the DDL emitters keep it.
     """
     if len(name) > 2 and name[0] == '"' and name[-1] == '"':
         inner = name[1:-1]
-        if (
-            inner == inner.upper()
-            and _PLAIN_IDENT.match(inner.lower())
-            and inner.lower() not in _RESERVED
-        ):
-            return inner.lower()
+        if inner == inner.upper():
+            return ident(inner)
     return name
 
 

--- a/src/pgrecon/convert/plsql_rewrite.py
+++ b/src/pgrecon/convert/plsql_rewrite.py
@@ -139,6 +139,18 @@ class _Rewriter(PlSqlParserListener):  # type: ignore[misc]
             if name is not None:
                 self._edit_ctx(name, _fold_written(self._span_text(name)) + "()")
                 self.suppressed.append((name.start.start, name.stop.stop))
+        if self.is_function:
+            spec = ctx.type_spec()
+            if (
+                spec is not None
+                and spec.PERCENT_ROWTYPE() is not None
+                and spec.type_name() is not None
+            ):
+                # A function returns a table's row type by the table's
+                # name on PostgreSQL; %ROWTYPE is for declarations only.
+                # The anchor itself is validated as any declaration is.
+                parts = [p.strip('"') for p in spec.type_name().getText().split(".")]
+                self._edit_ctx(spec, ident(parts[-1]))
         if ctx.seq_of_declare_specs() is not None:
             self.declares = True
         body = ctx.body()

--- a/tests/test_convert_code.py
+++ b/tests/test_convert_code.py
@@ -501,3 +501,13 @@ def test_rowtype_return_becomes_the_table_type(code_db: Path) -> None:
     assert "FUNCTION row_fn(p_kind IN varchar) RETURNS t_fees LANGUAGE plpgsql" in flat
     assert "l_row t_fees%ROWTYPE;" in flat
     assert "FROM t_fees WHERE kind = p_kind LIMIT 1;" in flat
+
+
+def test_quoted_uppercase_names_fold_like_the_ddl() -> None:
+    from pgrecon.convert.plsql_rewrite import _fold_written
+
+    assert _fold_written('"ADD_DATA"') == "add_data"
+    assert _fold_written('"RATE WITH SPACE 16"') == '"rate with space 16"'
+    assert _fold_written('"ORDER"') == '"order"'
+    assert _fold_written('"myFunc"') == '"myFunc"'
+    assert _fold_written("plain") == "plain"

--- a/tests/test_convert_code.py
+++ b/tests/test_convert_code.py
@@ -210,7 +210,15 @@ BEGIN
   WHEN MATCHED THEN UPDATE SET t.fee = 0 DELETE WHERE t.fee IS NULL;
 END merge_del_p;"""
 
+ROW_FN = """FUNCTION row_fn(p_kind IN VARCHAR2) RETURN t_fees%ROWTYPE IS
+  l_row t_fees%ROWTYPE;
+BEGIN
+  SELECT * INTO l_row FROM t_fees WHERE kind = p_kind AND ROWNUM = 1;
+  RETURN l_row;
+END row_fn;"""
+
 _UNITS = [
+    ("ROW_FN", "FUNCTION", ROW_FN),
     ("ROWNUM_P", "PROCEDURE", ROWNUM_P),
     ("ROWNUM_BAD_P", "PROCEDURE", ROWNUM_BAD_P),
     ("MERGE_P", "PROCEDURE", MERGE_P),
@@ -371,8 +379,8 @@ def test_refusal_cascades_to_callers(code_db: Path) -> None:
 
 def test_routine_count_matches_emitted(code_db: Path) -> None:
     result = convert_schema(code_db)
-    assert result.routines == 11
-    assert result.sql.count("LANGUAGE plpgsql") == 11
+    assert result.routines == 12
+    assert result.sql.count("LANGUAGE plpgsql") == 12
 
 
 def test_concatenation_carries_oracle_null_semantics(code_db: Path) -> None:
@@ -485,3 +493,11 @@ def test_merge_with_delete_refuses(code_db: Path) -> None:
     result = convert_schema(code_db)
     assert "merge_del_p" not in result.sql
     assert "second WHEN MATCHED" in _residue_reason(result, "MERGE_DEL_P")
+
+
+def test_rowtype_return_becomes_the_table_type(code_db: Path) -> None:
+    result = convert_schema(code_db)
+    flat = _flat(result.sql, "CREATE OR REPLACE FUNCTION row_fn")
+    assert "FUNCTION row_fn(p_kind IN varchar) RETURNS t_fees LANGUAGE plpgsql" in flat
+    assert "l_row t_fees%ROWTYPE;" in flat
+    assert "FROM t_fees WHERE kind = p_kind LIMIT 1;" in flat

--- a/tests/test_convert_code.py
+++ b/tests/test_convert_code.py
@@ -173,7 +173,48 @@ BEGIN
     USING v || 'x';
 END concat3_p;"""
 
+ROWNUM_P = """PROCEDURE rownum_p(p_min IN NUMBER, p_kind OUT VARCHAR2) IS
+  v_top VARCHAR2(30);
+BEGIN
+  SELECT kind INTO p_kind FROM t_fees WHERE fee > p_min AND ROWNUM = 1;
+  FOR r IN (SELECT kind FROM (SELECT kind FROM t_fees ORDER BY fee DESC)
+            WHERE ROWNUM <= 3) LOOP
+    v_top := r.kind;
+  END LOOP;
+  SELECT kind INTO v_top FROM t_fees WHERE ROWNUM < 2 AND kind IS NOT NULL;
+END rownum_p;"""
+
+ROWNUM_BAD_P = """PROCEDURE rownum_bad_p IS
+  v VARCHAR2(30);
+BEGIN
+  DELETE FROM t_fees WHERE ROWNUM <= 100;
+  SELECT kind INTO v FROM t_fees WHERE ROWNUM <= 5 ORDER BY fee;
+  SELECT COUNT(*) INTO v FROM t_fees WHERE ROWNUM <= 5;
+END rownum_bad_p;"""
+
+MERGE_P = """PROCEDURE merge_p(p_kind IN VARCHAR2, p_fee IN NUMBER) IS
+BEGIN
+  MERGE INTO t_fees t
+  USING (SELECT p_kind AS kind, p_fee AS fee FROM dual) s
+  ON (t.kind = s.kind)
+  WHEN MATCHED THEN UPDATE SET t.fee = s.fee, t.tag = 'seen' WHERE s.fee > 0
+  WHEN NOT MATCHED THEN INSERT (kind, fee) VALUES (s.kind, s.fee)
+    WHERE s.fee IS NOT NULL;
+  MERGE INTO t_fees t USING dual ON (t.kind = p_kind)
+  WHEN NOT MATCHED THEN INSERT (kind, tag) VALUES (p_kind, TO_CHAR(SYSDATE, 'YYYY'));
+END merge_p;"""
+
+MERGE_DEL_P = """PROCEDURE merge_del_p IS
+BEGIN
+  MERGE INTO t_fees t USING (SELECT 'a' AS kind FROM dual) s ON (t.kind = s.kind)
+  WHEN MATCHED THEN UPDATE SET t.fee = 0 DELETE WHERE t.fee IS NULL;
+END merge_del_p;"""
+
 _UNITS = [
+    ("ROWNUM_P", "PROCEDURE", ROWNUM_P),
+    ("ROWNUM_BAD_P", "PROCEDURE", ROWNUM_BAD_P),
+    ("MERGE_P", "PROCEDURE", MERGE_P),
+    ("MERGE_DEL_P", "PROCEDURE", MERGE_DEL_P),
     ("FEE_FOR", "FUNCTION", FEE_FOR),
     ("AUTON_P", "PROCEDURE", AUTON_P),
     ("FN_COMMIT", "FUNCTION", FN_COMMIT),
@@ -330,8 +371,8 @@ def test_refusal_cascades_to_callers(code_db: Path) -> None:
 
 def test_routine_count_matches_emitted(code_db: Path) -> None:
     result = convert_schema(code_db)
-    assert result.routines == 9
-    assert result.sql.count("LANGUAGE plpgsql") == 9
+    assert result.routines == 11
+    assert result.sql.count("LANGUAGE plpgsql") == 11
 
 
 def test_concatenation_carries_oracle_null_semantics(code_db: Path) -> None:
@@ -397,3 +438,50 @@ def test_format_model_note_surfaces(code_db: Path) -> None:
         if r.object_name == "FEE_FOR" and r.kind == "note"
     ]
     assert any("format models" in n for n in notes)
+
+
+def _flat(sql: str, start: str) -> str:
+    """One statement's text from `start`, whitespace collapsed."""
+    body = sql[sql.index(start) :]
+    body = body[: body.index("$body$;")]
+    return " ".join(body.split())
+
+
+def test_rownum_top_n_bounds_become_limit(code_db: Path) -> None:
+    result = convert_schema(code_db)
+    flat = _flat(result.sql, "CREATE OR REPLACE PROCEDURE rownum_p")
+    assert "FROM t_fees WHERE fee > p_min LIMIT 1;" in flat
+    assert (
+        "(SELECT kind FROM (SELECT kind FROM t_fees ORDER BY fee DESC) LIMIT 3)" in flat
+    )
+    assert "FROM t_fees WHERE kind IS NOT NULL LIMIT 1;" in flat
+    assert "ROWNUM" not in flat.upper().replace("ROWNUM_P", "")
+
+
+def test_rownum_outside_the_idiom_refuses_by_shape(code_db: Path) -> None:
+    result = convert_schema(code_db)
+    assert "rownum_bad_p" not in result.sql
+    reason = _residue_reason(result, "ROWNUM_BAD_P")
+    assert "DELETE or UPDATE" in reason
+    assert "ORDER BY" in reason
+    assert "aggregate" in reason
+
+
+def test_merge_carries_over_with_conditions_on_the_when(code_db: Path) -> None:
+    result = convert_schema(code_db)
+    flat = _flat(result.sql, "CREATE OR REPLACE PROCEDURE merge_p")
+    assert "USING (SELECT p_kind AS kind, p_fee AS fee ) s ON (t.kind = s.kind)" in flat
+    assert (
+        "WHEN MATCHED AND (s.fee > 0) THEN UPDATE SET fee = s.fee, tag = 'seen'"
+        " WHEN NOT MATCHED AND (s.fee IS NOT NULL) THEN INSERT (kind, fee)"
+        " VALUES (s.kind, s.fee) ;" in flat
+    )
+    assert "USING (SELECT 1) AS dual ON (t.kind = p_kind)" in flat
+    assert "VALUES (p_kind, TO_CHAR(CURRENT_TIMESTAMP, 'YYYY'))" in flat
+    assert "WHERE" not in flat.split("WHEN MATCHED")[1].split("WHEN NOT MATCHED")[0]
+
+
+def test_merge_with_delete_refuses(code_db: Path) -> None:
+    result = convert_schema(code_db)
+    assert "merge_del_p" not in result.sql
+    assert "second WHEN MATCHED" in _residue_reason(result, "MERGE_DEL_P")

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -1615,13 +1615,33 @@ class Estate:
                     f"BEGIN\n  SELECT {tcol} INTO p_out FROM {tbl} WHERE {pk} = p_id;\n"
                     "  IF p_out = '' THEN\n    p_out := 'empty';\n  END IF;\nEND;"
                 )
-            elif shape < 0.9 and funcs:
+            elif shape < 0.82 and funcs:
                 callee = rng.choice(funcs)
                 body = (
                     f"PROCEDURE {pname}(p_id IN NUMBER) IS\n  l NUMBER;\nBEGIN\n"
                     f"  l := {self.ref(callee)}(p_id);\n  COMMIT;\nEND;"
                 )
                 deps = [(callee, "FUNCTION")]
+            elif shape < 0.88:
+                body = (
+                    f"PROCEDURE {pname}(p_id IN NUMBER, p_name IN VARCHAR2) IS\n"
+                    f"BEGIN\n  MERGE INTO {tbl} t\n"
+                    "  USING (SELECT p_id AS id, p_name AS name FROM dual) s\n"
+                    f"  ON (t.{pk} = s.id)\n"
+                    f"  WHEN MATCHED THEN UPDATE SET t.{tcol} = s.name"
+                    " WHERE s.name IS NOT NULL\n"
+                    f"  WHEN NOT MATCHED THEN INSERT ({pk}, {tcol})"
+                    " VALUES (s.id, s.name);\n"
+                    "END;"
+                )
+            elif shape < 0.94:
+                body = (
+                    f"PROCEDURE {pname}(p_min IN NUMBER, p_out OUT VARCHAR2)"
+                    " IS\nBEGIN\n"
+                    f"  SELECT {tcol} INTO p_out FROM {tbl}"
+                    f" WHERE {pk} > p_min AND ROWNUM = 1;\n"
+                    "END;"
+                )
             else:
                 body = (
                     f"PROCEDURE {pname} IS\n  l_f UTL_FILE.FILE_TYPE;\nBEGIN\n"


### PR DESCRIPTION
0.7 code lane: two idioms the routine converter used to refuse now convert.

**ROWNUM.** A bound that is a plain conjunct of a SELECT's WHERE (`ROWNUM = 1`, `ROWNUM <= n`, `ROWNUM < n`) becomes `LIMIT` on that query: the `SELECT ... INTO ... WHERE ... AND ROWNUM = 1` lookup, the sorted-subquery top-N, cursor FOR loops over either. Oracle numbers rows before ORDER BY, GROUP BY, DISTINCT, aggregates, and set operations, so a bound beside any of those in the same query declines with the reason; so do ROWNUM under OR, in DELETE/UPDATE, compared with a non-integer, or bounded twice. LIMIT is placed at the query's end, ahead of FOR UPDATE.

**MERGE.** Statements carry over: an action's trailing `WHERE` moves onto its `WHEN` as `AND (...)` (token rewrites inside the condition are carried along at assembly), `SET t.col` loses the alias PostgreSQL rejects, `USING dual` becomes `(SELECT 1) AS dual`. `WHEN MATCHED ... DELETE` declines by name.

Tests: four new code-lane units (happy ROWNUM shapes, three ROWNUM refusals, a two-statement MERGE, the DELETE refusal); the fuzzer generator emits both shapes; 30 fresh seeds obey the laws locally.