### PR TITLE
extract: capture string length semantics and map widths by characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,14 @@ Release notes are written by hand, grouped by area. Dates use YYYY-MM-DD.
   clause as AND (...), SET t.col loses the alias PostgreSQL rejects,
   and USING dual becomes a one-row source; WHEN MATCHED ... DELETE
   declines by name.
+- String length semantics. Both extraction scripts now capture
+  CHAR_LENGTH and CHAR_USED for every column, and string widths map by
+  characters - what PostgreSQL counts - so VARCHAR2(30 CHAR) becomes
+  varchar(30) instead of varchar(120), and NVARCHAR2(200) varchar(200)
+  instead of varchar(400). R-TYPE-09 (info) reports columns declared
+  in BYTE semantics in a multibyte database, where the converted
+  columns accept more text than Oracle did, and the converter leaves a
+  note per affected table; the catalog is at 80 rules.
 - The bundled example dump is regenerated from the Oracle-loop job:
   35 spool files including grants, comments, character set, license
   posture, feature usage, partition bounds, sequences, and column

--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ variant for you.
 
 ## What it checks
 
-79 rules at present, each shipping with fixture tests:
+80 rules at present, each shipping with fixture tests:
 
 | Category        | Rules | Among them |
 | --------------- | ----- | ---------- |
 | Environment     | 2     | character-set encoding decision, object grants to migrate |
-| Data types      | 8     | LONG, XMLTYPE, ROWID and BFILE, SDO_GEOMETRY, TIMESTAMP WITH LOCAL TIME ZONE |
+| Data types      | 9     | LONG, XMLTYPE, ROWID and BFILE, SDO_GEOMETRY, BYTE-semantics strings, TIMESTAMP WITH LOCAL TIME ZONE |
 | Storage         | 12    | interval partitioning, global temporary tables, IOTs, read-only tables, bitmap and function-based indexes |
 | PL/SQL code     | 18    | autonomous transactions, dynamic SQL, FORALL, collection types, the empty-string NULL trap |
 | SQL constructs  | 13    | CONNECT BY, (+) outer joins, ROWNUM, MERGE, SYS_CONTEXT, the MODEL clause, PIVOT, flashback queries |

--- a/src/pgrecon/convert/constraints.py
+++ b/src/pgrecon/convert/constraints.py
@@ -83,8 +83,9 @@ def _mapped_types(
     types: list[str | None] = []
     for name in columns:
         row = conn.execute(
-            "SELECT data_type, data_length, data_precision, data_scale FROM columns"
-            " WHERE owner = ? AND table_name = ? AND UPPER(column_name) = ?",
+            "SELECT data_type, data_length, data_precision, data_scale, char_length"
+            " FROM columns WHERE owner = ? AND table_name = ?"
+            " AND UPPER(column_name) = ?",
             (owner, table, name.upper()),
         ).fetchone()
         if row is None:
@@ -96,6 +97,7 @@ def _mapped_types(
                 row["data_length"],
                 row["data_precision"],
                 row["data_scale"],
+                row["char_length"],
             ).pg_type
         )
     return types

--- a/src/pgrecon/convert/tables.py
+++ b/src/pgrecon/convert/tables.py
@@ -64,16 +64,33 @@ def _column_families(
     expression guards."""
     families: dict[str, str] = {}
     for r in conn.execute(
-        "SELECT column_name, data_type, data_length, data_precision, data_scale"
-        " FROM columns WHERE owner = ? AND table_name = ?",
+        "SELECT column_name, data_type, data_length, data_precision, data_scale,"
+        " char_length FROM columns WHERE owner = ? AND table_name = ?",
         (owner, table),
     ):
         mapped = map_type(
-            r["data_type"], r["data_length"], r["data_precision"], r["data_scale"]
+            r["data_type"],
+            r["data_length"],
+            r["data_precision"],
+            r["data_scale"],
+            r["char_length"],
         ).pg_type
         if mapped is not None:
             families[(r["column_name"] or "").upper()] = expression_family(mapped)
     return families
+
+
+_MULTIBYTE_PREFIXES = ("AL32", "AL16", "UTF", "ZHS16", "ZHT16", "JA16", "KO16")
+
+
+def _multibyte_database(conn: sqlite3.Connection) -> bool:
+    """Whether the source character set spends more than one byte on
+    some characters, which is when BYTE-semantics widths bite."""
+    row = conn.execute(
+        "SELECT value FROM nls_params WHERE key = 'NLS_CHARACTERSET'"
+    ).fetchone()
+    charset = (row[0] or "").upper() if row else ""
+    return charset.startswith(_MULTIBYTE_PREFIXES)
 
 
 def _date_columns(conn: sqlite3.Connection, owner: str, table: str) -> set[str]:
@@ -91,7 +108,7 @@ def _date_columns(conn: sqlite3.Connection, owner: str, table: str) -> set[str]:
 def _columns(conn: sqlite3.Connection, owner: str, table: str) -> list[sqlite3.Row]:
     return conn.execute(
         "SELECT column_name, data_type, data_length, data_precision,"
-        " data_scale, nullable FROM columns"
+        " data_scale, nullable, char_length, char_used FROM columns"
         " WHERE owner = ? AND table_name = ? ORDER BY position",
         (owner, table),
     ).fetchall()
@@ -156,6 +173,7 @@ def emit_tables(
     tables = conn.execute(
         "SELECT owner, table_name, temporary FROM tables ORDER BY owner, table_name"
     ).fetchall()
+    multibyte = _multibyte_database(conn)
 
     for t in tables:
         owner, table = t["owner"], t["table_name"]
@@ -200,7 +218,11 @@ def emit_tables(
         families = _column_families(conn, owner, table)
         for c in cols:
             mapped = map_type(
-                c["data_type"], c["data_length"], c["data_precision"], c["data_scale"]
+                c["data_type"],
+                c["data_length"],
+                c["data_precision"],
+                c["data_scale"],
+                c["char_length"],
             )
             if mapped.pg_type is None:
                 residue.append(
@@ -373,6 +395,26 @@ def emit_tables(
                 Residue(owner, table, "table", "every column was unconvertible")
             )
             continue
+        byte_sized = [
+            c["column_name"]
+            for c in cols
+            if (c["char_used"] or "").upper() == "B"
+            and (c["data_type"] or "").upper() in ("VARCHAR2", "CHAR", "VARCHAR")
+            and (c["column_name"] or "").upper() in kept_columns
+        ]
+        if byte_sized and multibyte:
+            residue.append(
+                Residue(
+                    owner,
+                    table,
+                    "note",
+                    f"{len(byte_sized)} string column(s) were declared in BYTE"
+                    " semantics; PostgreSQL counts characters, so they accept"
+                    " more text than Oracle did - add CHECK"
+                    " (octet_length(col) <= n) where the byte limit carried"
+                    " meaning",
+                )
+            )
         meta, part_reason = _partition_meta(conn, owner, table)
         if meta is not None:
             # PostgreSQL cannot partition by a generated column, nor by

--- a/src/pgrecon/convert/typemap.py
+++ b/src/pgrecon/convert/typemap.py
@@ -36,11 +36,26 @@ def _fractional(base: str, digits: str) -> Mapped:
     return Mapped(f"{base}({precision})")
 
 
+def _char_width(dtype: str, length: int | None, char_length: int | None) -> int | None:
+    """The declared width in characters, which PostgreSQL lengths count.
+
+    CHAR_LENGTH is the declared width whatever the semantics were; a
+    dump without it (older extraction scripts) falls back to the byte
+    length, halved for the national types whose bytes are UTF-16.
+    """
+    if char_length:
+        return char_length
+    if length and dtype in ("NVARCHAR2", "NCHAR"):
+        return max(length // 2, 1)
+    return length
+
+
 def map_type(
     data_type: str | None,
     length: int | None,
     precision: int | None,
     scale: int | None,
+    char_length: int | None = None,
 ) -> Mapped:
     dtype = (data_type or "").strip().upper()
 
@@ -64,9 +79,11 @@ def map_type(
         return Mapped("double precision")
 
     if dtype in ("VARCHAR2", "NVARCHAR2", "VARCHAR"):
-        return Mapped(f"varchar({length})" if length else "varchar")
+        width = _char_width(dtype, length, char_length)
+        return Mapped(f"varchar({width})" if width else "varchar")
     if dtype in ("CHAR", "NCHAR"):
-        return Mapped(f"char({length})" if length else "char")
+        width = _char_width(dtype, length, char_length)
+        return Mapped(f"char({width})" if width else "char")
     if dtype in ("CLOB", "NCLOB"):
         return Mapped("text")
     if dtype == "LONG":

--- a/src/pgrecon/extract/pgrecon_extract.sql
+++ b/src/pgrecon/extract/pgrecon_extract.sql
@@ -134,7 +134,9 @@ SELECT owner,
        data_length,
        data_precision,
        data_scale,
-       nullable
+       nullable,
+       char_length,
+       char_used
   FROM all_tab_columns
  WHERE owner = UPPER('&schema')
    AND table_name NOT LIKE 'BIN$%'

--- a/src/pgrecon/extract/pgrecon_extract_legacy.sql
+++ b/src/pgrecon/extract/pgrecon_extract_legacy.sql
@@ -104,7 +104,8 @@ SPOOL OFF
 
 SPOOL columns.csv
 SELECT '"OWNER","TABLE_NAME","COLUMN_NAME","COLUMN_ID","DATA_TYPE",'
-       || '"DATA_LENGTH","DATA_PRECISION","DATA_SCALE","NULLABLE"'
+       || '"DATA_LENGTH","DATA_PRECISION","DATA_SCALE","NULLABLE",'
+       || '"CHAR_LENGTH","CHAR_USED"'
   FROM dual;
 SELECT '"' || owner || '","' || REPLACE(table_name, '"', '""') || '","'
        || REPLACE(column_name, '"', '""') || '",'
@@ -113,7 +114,9 @@ SELECT '"' || owner || '","' || REPLACE(table_name, '"', '""') || '","'
        || NVL(TO_CHAR(data_length), '') || ','
        || NVL(TO_CHAR(data_precision), '') || ','
        || NVL(TO_CHAR(data_scale), '') || ',"'
-       || nullable || '"'
+       || nullable || '",'
+       || NVL(TO_CHAR(char_length), '') || ',"'
+       || NVL(char_used, '') || '"'
   FROM all_tab_columns
  WHERE owner = UPPER('&schema')
    AND table_name NOT LIKE 'BIN$%'

--- a/src/pgrecon/inventory/loader.py
+++ b/src/pgrecon/inventory/loader.py
@@ -65,6 +65,8 @@ CSV_TABLES: dict[str, tuple[str, dict[str, str]]] = {
             "DATA_PRECISION": "data_precision",
             "DATA_SCALE": "data_scale",
             "NULLABLE": "nullable",
+            "CHAR_LENGTH": "char_length",
+            "CHAR_USED": "char_used",
         },
     ),
     "source.csv": (
@@ -344,6 +346,7 @@ INT_COLUMNS = {
     "data_length",
     "data_precision",
     "data_scale",
+    "char_length",
     "line",
     "count",
     "partition_count",

--- a/src/pgrecon/inventory/schema.sql
+++ b/src/pgrecon/inventory/schema.sql
@@ -37,6 +37,10 @@ CREATE TABLE columns (
     data_precision INTEGER,
     data_scale     INTEGER,
     nullable       TEXT,
+    -- Declared width in characters and whether the declaration counted
+    -- bytes (B) or characters (C); PostgreSQL lengths count characters.
+    char_length    INTEGER,
+    char_used      TEXT,
     PRIMARY KEY (owner, table_name, column_name)
 );
 

--- a/src/pgrecon/rules/columns.py
+++ b/src/pgrecon/rules/columns.py
@@ -148,4 +148,31 @@ RULES = [
             " data_type FROM columns WHERE data_type LIKE 'SDO_%'"
         ),
     ),
+    Rule(
+        id="R-TYPE-09",
+        title="String lengths declared in bytes",
+        category="data types",
+        severity=Severity.INFO,
+        effort=0.5,
+        remedy=(
+            "VARCHAR2 and CHAR columns declared without CHAR semantics limit"
+            " bytes, and in a multibyte database a 30-byte column holds fewer"
+            " than 30 characters of non-ASCII text. PostgreSQL lengths count"
+            " characters, so the converted columns accept more text than"
+            " Oracle did; add CHECK (octet_length(col) <= n) where the byte"
+            " limit carried meaning, and expect NLS_LENGTH_SEMANTICS to stop"
+            " mattering."
+        ),
+        detector=sql_detector(
+            "SELECT owner, COUNT(*) || ' string columns', 'SCHEMA',"
+            " 'declared in BYTE semantics; PostgreSQL counts characters'"
+            " FROM columns WHERE char_used = 'B'"
+            " AND data_type IN ('VARCHAR2', 'CHAR', 'VARCHAR')"
+            " AND EXISTS (SELECT 1 FROM nls_params WHERE key = 'NLS_CHARACTERSET'"
+            "   AND (value LIKE 'AL32%' OR value LIKE 'AL16%' OR value LIKE 'UTF%'"
+            "   OR value LIKE 'ZHS16%' OR value LIKE 'ZHT16%' OR value LIKE 'JA16%'"
+            "   OR value LIKE 'KO16%'))"
+            " GROUP BY owner"
+        ),
+    ),
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,7 +122,7 @@ def test_explain_lists_catalog() -> None:
     result = runner.invoke(app, ["explain"])
     assert result.exit_code == 0
     assert "R-TYPE-01" in result.output
-    assert "79 rules" in result.output
+    assert "80 rules" in result.output
 
 
 def test_explain_rejects_unknown_id() -> None:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1695,3 +1695,40 @@ def test_view_over_a_column_the_table_lacks_declines(facts_db: Path) -> None:
     assert "CREATE OR REPLACE VIEW v_aliased" in result.sql
     reasons = {r.object_name: r.reason for r in result.residue if r.kind == "view"}
     assert "GHOST, which is not a column of EMP" in reasons["V_TORN"]
+
+
+def test_string_widths_count_characters() -> None:
+    # CHAR semantics: the catalog byte length is four times the width.
+    assert map_type("VARCHAR2", 120, None, None, 30).pg_type == "varchar(30)"
+    assert map_type("CHAR", 12, None, None, 3).pg_type == "char(3)"
+    # National types without CHAR_LENGTH (older dumps): UTF-16 bytes.
+    assert map_type("NVARCHAR2", 400, None, None).pg_type == "varchar(200)"
+    assert map_type("NCHAR", 10, None, None).pg_type == "char(5)"
+    assert map_type("NVARCHAR2", 400, None, None, 200).pg_type == "varchar(200)"
+    # BYTE semantics: bytes and characters agree, so nothing changes.
+    assert map_type("VARCHAR2", 30, None, None, 30).pg_type == "varchar(30)"
+
+
+def test_byte_semantics_note_needs_a_multibyte_database(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.executescript(
+        """
+        UPDATE columns SET char_length = data_length, char_used = 'B'
+         WHERE data_type = 'VARCHAR2';
+        INSERT INTO nls_params (key, value) VALUES ('NLS_CHARACTERSET', 'WE8ISO8859P1');
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    assert not [r for r in result.residue if "BYTE semantics" in r.reason]
+    conn = sqlite3.connect(facts_db)
+    conn.execute("UPDATE nls_params SET value = 'AL32UTF8'")
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    notes = [r for r in result.residue if "BYTE semantics" in r.reason]
+    assert {r.object_name for r in notes} == {"DEPT", "EMP"}
+    assert "1 string column(s)" in next(
+        r.reason for r in notes if r.object_name == "EMP"
+    )

--- a/tests/test_convert_code.py
+++ b/tests/test_convert_code.py
@@ -271,7 +271,9 @@ def code_db(tmp_path: Path) -> Path:
         INSERT INTO objects VALUES ('AX', 'PKG_X', 'PACKAGE', 'VALID', NULL, NULL);
         INSERT INTO objects VALUES ('AX', 'TY_Y', 'TYPE', 'VALID', NULL, NULL);
         INSERT INTO tables (owner, table_name) VALUES ('AX', 'T_FEES');
-        INSERT INTO columns VALUES
+        INSERT INTO columns (owner, table_name, column_name, position, data_type,
+                             data_length, data_precision, data_scale, nullable)
+          VALUES
             ('AX', 'T_FEES', 'KIND', 1, 'VARCHAR2', 30, NULL, NULL, 'Y'),
             ('AX', 'T_FEES', 'FEE', 2, 'NUMBER', 22, 10, 2, 'Y'),
             ('AX', 'T_FEES', 'TAG', 3, 'VARCHAR2', 60, NULL, NULL, 'Y');

--- a/tests/test_convert_triggers.py
+++ b/tests/test_convert_triggers.py
@@ -95,7 +95,9 @@ def trigger_db(tmp_path: Path) -> Path:
         INSERT INTO objects VALUES ('AX', 'AUDIT_LOG', 'TABLE', 'VALID', NULL, NULL);
         INSERT INTO tables (owner, table_name) VALUES ('AX', 'T_FEES');
         INSERT INTO tables (owner, table_name) VALUES ('AX', 'AUDIT_LOG');
-        INSERT INTO columns VALUES
+        INSERT INTO columns (owner, table_name, column_name, position, data_type,
+                             data_length, data_precision, data_scale, nullable)
+          VALUES
             ('AX', 'T_FEES', 'FEE', 1, 'NUMBER', 22, 10, 2, 'Y'),
             ('AX', 'T_FEES', 'TAG', 2, 'VARCHAR2', 30, NULL, NULL, 'Y'),
             ('AX', 'AUDIT_LOG', 'AUDIT_ID', 1, 'NUMBER', 22, 10, 0, 'Y');

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -420,3 +420,25 @@ def test_ddl_marker_accepts_names_with_spaces(tmp_path: Path) -> None:
     names = {r[0] for r in conn.execute("SELECT name FROM ddl WHERE type = 'VIEW'")}
     conn.close()
     assert names == {"V WITH SPACE", "V, COMMA"}
+
+
+def test_char_semantics_columns_load(tmp_path: Path) -> None:
+    dump = tmp_path / "dump"
+    dump.mkdir()
+    (dump / "columns.csv").write_text(
+        "\n"
+        '"OWNER","TABLE_NAME","COLUMN_NAME","COLUMN_ID","DATA_TYPE","DATA_LENGTH",'
+        '"DATA_PRECISION","DATA_SCALE","NULLABLE","CHAR_LENGTH","CHAR_USED"\n'
+        '"HR","T","NAME",1,"VARCHAR2",120,,,"Y",30,"C"\n'
+        '"HR","T","CODE",2,"VARCHAR2",10,,,"Y",10,"B"\n',
+        encoding="utf-8",
+    )
+    db = tmp_path / "inv.db"
+    load_dump(dump, db)
+    conn = sqlite3.connect(db)
+    rows = conn.execute(
+        "SELECT column_name, data_length, char_length, char_used FROM columns"
+        " ORDER BY position"
+    ).fetchall()
+    conn.close()
+    assert rows == [("NAME", 120, 30, "C"), ("CODE", 10, 10, "B")]

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -823,6 +823,11 @@ _RULE_FIXTURES = {
         "INSERT INTO plsql_calls (owner, name, type, callee, line) VALUES"
         " ('HR', 'SYNC_IT', 'PROCEDURE', 'REMOTE_PKG.LOG_IT@SALES_LINK', 7)"
     ),
+    "R-TYPE-09": (
+        "INSERT INTO columns (owner, table_name, column_name, data_type, data_length,"
+        " char_length, char_used) VALUES ('HR', 'T', 'NAME', 'VARCHAR2', 30, 30, 'B');"
+        " INSERT INTO nls_params (key, value) VALUES ('NLS_CHARACTERSET', 'AL32UTF8')"
+    ),
 }
 
 

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -22,6 +22,7 @@ import argparse
 import csv
 import json
 import random
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -57,6 +58,8 @@ HEADERS: dict[str, list[str]] = {
         "DATA_PRECISION",
         "DATA_SCALE",
         "NULLABLE",
+        "CHAR_LENGTH",
+        "CHAR_USED",
     ],
     "source.csv": ["OWNER", "NAME", "TYPE", "LINE", "TEXT"],
     "features.csv": ["FEATURE", "DETAIL", "CNT"],
@@ -346,6 +349,21 @@ def q(name: str) -> str:
     return '"' + name + '"'
 
 
+_DECLARED_WIDTH = re.compile(r"\((\d+)( CHAR| BYTE)?\)")
+
+
+def char_facts(data_type: str, ddl: str) -> tuple[int | None, str | None]:
+    """CHAR_LENGTH and CHAR_USED as the catalog reports them for a
+    string column: the declared width in characters, and B or C."""
+    if data_type not in TEXTUAL:
+        return None, None
+    m = _DECLARED_WIDTH.search(ddl)
+    if m is None:
+        return None, None
+    used = "C" if (m.group(2) or "").strip() == "CHAR" or data_type[0] == "N" else "B"
+    return int(m.group(1)), used
+
+
 def esc(text: str) -> str:
     return text.replace("'", "''")
 
@@ -599,6 +617,7 @@ class Estate:
                 c.precision,
                 c.scale,
                 "Y" if c.nullable else "N",
+                *char_facts(c.data_type, c.ddl),
             )
             if c.data_type in LOBS:
                 lob = f"SYS_LOB{self.sys_counter:07d}C{pos:05d}$$"
@@ -883,6 +902,7 @@ class Estate:
             col.precision,
             col.scale,
             "Y",
+            *char_facts(col.data_type, col.ddl),
         )
         return name
 
@@ -1395,6 +1415,11 @@ class Estate:
                     dtype.precision if dtype else None,
                     dtype.scale if dtype else None,
                     "Y",
+                    *(
+                        char_facts(dtype.data_type, dtype.ddl)
+                        if dtype
+                        else (None, None)
+                    ),
                 )
             iname = f"I_SNAP$_{name}"[:120]
             self.add(


### PR DESCRIPTION
0.7: the last review gap from round 3.

- Both extraction tiers spool `CHAR_LENGTH` and `CHAR_USED` for every column. The Oracle-loop job runs on this PR (11g, 21c, 23ai) and exercises the new SQL against live Oracle.
- String widths map by characters, which PostgreSQL counts: `VARCHAR2(30 CHAR)` (catalog byte length 120 under AL32UTF8) becomes `varchar(30)` instead of `varchar(120)`; `NVARCHAR2(200)` becomes `varchar(200)` instead of `varchar(400)`. Older dumps without the columns fall back to the byte length, halved for national types.
- **R-TYPE-09** (info, 0.5): columns declared in BYTE semantics in a multibyte database, one finding per schema with the count. The converter adds one note per affected table naming the `CHECK (octet_length(...))` that restores the byte limit where it carried meaning. Catalog at 80 rules.
- Loader stores the two facts; the fuzzer's generator emits them as the catalog would; two tests that inserted column rows positionally now name their columns.

The bundled example dump still predates these columns; it gets refreshed from the Oracle-loop artifact in the release PR, along with the headline numbers.