### PR TITLE
convert: decline defaults that cannot fit and hierarchies across types

### DIFF
--- a/src/pgrecon/convert/tables.py
+++ b/src/pgrecon/convert/tables.py
@@ -2,6 +2,7 @@
 
 import re
 import sqlite3
+from decimal import Decimal
 
 from pgrecon.convert.identifiers import (
     _date_function_guard,
@@ -36,13 +37,35 @@ _EMPTY_LOBS = {"EMPTY_CLOB()": "''", "EMPTY_BLOB()": "''::bytea"}
 _STRING_LITERAL = re.compile(r"^'((?:[^']|'')*)'$")
 
 
+_NUMERIC_LITERAL = re.compile(r"^-?\d+(?:\.\d+)?$")
+
+
 def _literal_length_guard(folded: str, column: sqlite3.Row) -> str | None:
-    """A string default longer than its column: Oracle accepts the
-    table and rejects the row; PostgreSQL rejects the table."""
-    m = _STRING_LITERAL.match(folded.strip())
+    """A literal default its column cannot hold: Oracle accepts the
+    table and rejects the row; PostgreSQL rejects the table.
+
+    Strings longer than the declared width, and numbers whose integer
+    part exceeds what NUMBER(p, s) leaves room for - NUMBER(5, 10)
+    holds nothing at or above 0.00001, so DEFAULT -1 can never apply.
+    """
+    dtype = (column["data_type"] or "").upper()
+    text = folded.strip()
+    if dtype == "NUMBER" and _NUMERIC_LITERAL.match(text):
+        precision = column["data_precision"]
+        if precision is None:
+            return None
+        scale = column["data_scale"] or 0
+        room = precision - scale
+        magnitude = abs(Decimal(text))
+        if (room <= 0 and magnitude != 0) or magnitude >= Decimal(10) ** room:
+            return (
+                f"default {text} cannot fit NUMBER({precision},{scale}); Oracle"
+                " would reject the row, PostgreSQL rejects the table"
+            )
+        return None
+    m = _STRING_LITERAL.match(text)
     if m is None:
         return None
-    dtype = (column["data_type"] or "").upper()
     length = column["data_length"]
     if dtype not in ("VARCHAR2", "NVARCHAR2", "CHAR", "NCHAR") or not length:
         return None

--- a/src/pgrecon/convert/views.py
+++ b/src/pgrecon/convert/views.py
@@ -2,6 +2,7 @@
 
 import re
 import sqlite3
+from collections.abc import Callable
 
 import sqlglot
 from sqlglot import Expr, exp
@@ -128,7 +129,11 @@ def _view_guard(
     return None
 
 
-def _connect_by_view(tree: Expr, declared: list[str]) -> tuple[str | None, str | None]:
+def _connect_by_view(
+    tree: Expr,
+    declared: list[str],
+    families: Callable[[str], dict[str, str]] | None = None,
+) -> tuple[str | None, str | None]:
     """A hierarchical query as WITH RECURSIVE, or a named refusal.
 
     The provable subset: one table, one PRIOR equality, projections of
@@ -180,6 +185,19 @@ def _connect_by_view(tree: Expr, declared: list[str]) -> tuple[str | None, str |
         )
     parent_col = ident(prior_inner.name)
     child_col = ident(plains[0].name)
+    source_tables = list(select.find_all(exp.Table))
+    if families is not None and len(source_tables) == 1:
+        # Oracle compares NUMBER with VARCHAR2 by converting one side;
+        # PostgreSQL has no such operator, so the join would not parse.
+        known = families(source_tables[0].name)
+        parent_family = known.get(prior_inner.name.upper())
+        child_family = known.get(plains[0].name.upper())
+        if parent_family and child_family and parent_family != child_family:
+            return None, (
+                f"PRIOR {parent_col} = {child_col} compares {parent_family} with"
+                f" {child_family}; Oracle converts implicitly, PostgreSQL does"
+                " not - cast one side by hand"
+            )
     start = connect.args.get("start")
     if start is not None and (
         any(True for _ in start.find_all(exp.Prior))
@@ -324,6 +342,15 @@ def _emit_views(
     count = 0
     wrote = False
     created_views: set[str] = set()
+    # Column families of the converted tables, for the hierarchy guard.
+    by_upper = {t.upper(): (o, t) for (o, t) in emitted}
+
+    def families(table: str) -> dict[str, str]:
+        from pgrecon.convert.tables import _column_families
+
+        found = by_upper.get(table.upper())
+        return _column_families(conn, *found) if found else {}
+
     for name in ordered:
         r = by_name[name]
         text = _VIEW_HEADER_NOISE.sub("", r["ddl"] or "")
@@ -384,7 +411,7 @@ def _emit_views(
                     if isinstance(folded.this, exp.Schema)
                     else []
                 )
-                built, why = _connect_by_view(folded, declared)
+                built, why = _connect_by_view(folded, declared, families)
                 if built is None:
                     residue.append(
                         Residue(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1732,3 +1732,56 @@ def test_byte_semantics_note_needs_a_multibyte_database(facts_db: Path) -> None:
     assert "1 string column(s)" in next(
         r.reason for r in notes if r.object_name == "EMP"
     )
+
+
+def test_numeric_defaults_must_fit_precision_and_scale(tmp_path: Path) -> None:
+    db = tmp_path / "inv.db"
+    conn = open_db(db)
+    conn.executescript(
+        """
+        INSERT INTO tables (owner, table_name, temporary) VALUES ('HR', 'RATES', 'N');
+        INSERT INTO columns
+          (owner, table_name, column_name, position, data_type,
+           data_length, data_precision, data_scale, nullable) VALUES
+          ('HR', 'RATES', 'ID',    1, 'NUMBER', 22, 10, 0, 'N'),
+          ('HR', 'RATES', 'TINY',  2, 'NUMBER', 22, 5, 10, 'Y'),
+          ('HR', 'RATES', 'PRICE', 3, 'NUMBER', 22, 5, 2, 'Y'),
+          ('HR', 'RATES', 'BIG',   4, 'NUMBER', 22, 3, 0, 'Y'),
+          ('HR', 'RATES', 'ANY',   5, 'NUMBER', 22, NULL, NULL, 'Y');
+        INSERT INTO column_defaults (owner, table_name, column_name, default_text,
+                                     virtual, truncated) VALUES
+          ('HR', 'RATES', 'TINY', '-1', 'NO', 0),
+          ('HR', 'RATES', 'PRICE', '999.99', 'NO', 0),
+          ('HR', 'RATES', 'BIG', '1000', 'NO', 0),
+          ('HR', 'RATES', 'ANY', '123456789012', 'NO', 0);
+        """
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(db)
+    sql = result.sql
+    assert "price numeric(5,2) DEFAULT 999.99" in sql
+    assert '"any" numeric DEFAULT 123456789012' in sql
+    assert "tiny numeric(5,10)," in sql
+    assert "big smallint," in sql
+    notes = {r.object_name: r.reason for r in result.residue if r.kind == "note"}
+    assert "cannot fit NUMBER(5,10)" in notes["RATES.TINY"]
+    assert "cannot fit NUMBER(3,0)" in notes["RATES.BIG"]
+
+
+def test_connect_by_across_type_families_refuses(facts_db: Path) -> None:
+    conn = sqlite3.connect(facts_db)
+    conn.execute(
+        "INSERT INTO ddl (owner, name, type, ddl, parse_ok, parse_quality) VALUES"
+        " ('HR', 'V_BAD_TREE', 'VIEW',"
+        ' \'CREATE OR REPLACE VIEW "HR"."V_BAD_TREE" AS SELECT "EMP_ID"'
+        ' FROM "HR"."EMP" CONNECT BY PRIOR "EMP_ID" = "HIRED"\', 1, \'full\')'
+    )
+    conn.commit()
+    conn.close()
+    result = convert_schema(facts_db)
+    # The number-to-number hierarchy still converts; the mixed one declines.
+    assert "WITH RECURSIVE hierarchy" in result.sql
+    assert "v_bad_tree" not in result.sql
+    reasons = {r.object_name: r.reason for r in result.residue if r.kind == "view"}
+    assert "Oracle converts implicitly" in reasons["V_BAD_TREE"]

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -1294,9 +1294,9 @@ class Estate:
             )
         if roll < 0.40 and num and txt:
             return (
-                [txt.name, "CNT", "TOTAL"],
-                f"SELECT {q(txt.name)}, COUNT(*) AS CNT, SUM(NVL({q(num.name)}, 0))"
-                f" AS TOTAL\n  FROM {t}\n GROUP BY {q(txt.name)}",
+                [txt.name, "AGG_CNT", "AGG_TOTAL"],
+                f"SELECT {q(txt.name)}, COUNT(*) AS AGG_CNT, SUM(NVL({q(num.name)}, 0))"
+                f" AS AGG_TOTAL\n  FROM {t}\n GROUP BY {q(txt.name)}",
                 deps,
             )
         if roll < 0.50 and len(self.tables) > 1:

--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -1091,11 +1091,24 @@ class Estate:
             ),
             None,
         )
+        # Oracle rejects a range bound its key cannot hold (ORA-14036):
+        # the numeric key for a range layout needs room for 1000.
+        num_range = next(
+            (
+                c
+                for c in table.columns
+                if c.data_type in NUMERIC
+                and (c.precision is None or c.precision - (c.scale or 0) >= 4)
+            ),
+            None,
+        )
         kinds = []
         if dat:
             kinds.append("RANGE_DATE")
+        if num_range:
+            kinds.append("RANGE_NUM")
         if num:
-            kinds += ["RANGE_NUM", "HASH"]
+            kinds.append("HASH")
         if txt:
             kinds.append("LIST")
         kinds += ["REFERENCE", "SYSTEM"] if rng.random() < 0.12 else []
@@ -1124,7 +1137,8 @@ class Estate:
                 parts.append(("P_MAX", "MAXVALUE", 0))
             elif rng.random() < 0.4:
                 interval = "NUMTOYMINTERVAL(1, 'MONTH')"
-        elif kind == "RANGE_NUM" and num:
+        elif kind == "RANGE_NUM" and num_range:
+            num = num_range
             ptype = "RANGE"
             key = [num.name]
             parts = [
@@ -1242,23 +1256,12 @@ class Estate:
             )
             self.add_grants(name, "SEQUENCE")
 
-    def make_colliding_sequence(self) -> None:
-        if self.tables and self.rng.random() < 0.15:
-            name = self.rng.choice(self.tables).name
-            self.sequences.append(name)
-            self.obj(name, "SEQUENCE")
-            self.add("sequences.csv", OWNER, name, "1", "9" * 28, "1", "N", "20", "7")
-
     def make_views(self) -> None:
         rng = self.rng
         tables = [t for t in self.tables if t.columns]
         for i in range(max(2, len(tables) // 3)):
             base = rng.choice(tables)
-            roll = rng.random()
-            if roll < 0.05:
-                name = rng.choice(tables).name  # collides with a table
-            else:
-                name = self.unique(self.styled_name("V", i, allow_reserved=False))
+            name = self.unique(self.styled_name("V", i, allow_reserved=False))
             cols, body, deps = self.view_body(base)
             header = ", ".join(q(c) for c in cols)
             self.views.append((name, cols))
@@ -1318,14 +1321,17 @@ class Estate:
                 )
         if roll < 0.58:
             # The hierarchy joins the key to a column of its own family.
-            mate = next(
-                (
-                    c
-                    for c in base.columns[1:]
-                    if (c.data_type in NUMERIC) == (c1.data_type in NUMERIC)
-                    and (c.data_type in TEXTUAL) == (c1.data_type in TEXTUAL)
-                ),
-                None,
+            family = (
+                NUMERIC
+                if c1.data_type in NUMERIC
+                else TEXTUAL
+                if c1.data_type in TEXTUAL
+                else None
+            )
+            mate = (
+                next((c for c in base.columns[1:] if c.data_type in family), None)
+                if family
+                else None
             )
             if mate is None:
                 # No column of the key's family: a plain projection instead.
@@ -1487,10 +1493,7 @@ class Estate:
         for i in range(rng.randint(3, 6)):
             roll = rng.random()
             owner = "PUBLIC" if roll < 0.15 else OWNER
-            if roll < 0.05 and self.tables:
-                name = rng.choice(self.tables).name
-            else:
-                name = self.unique(self.styled_name("SYN", i, allow_reserved=False))
+            name = self.unique(self.styled_name("SYN", i, allow_reserved=False))
             if owner == OWNER:
                 self.obj(name, "SYNONYM")
             target, _ = rng.choice(targets)
@@ -1902,7 +1905,6 @@ class Estate:
     def build(self) -> None:
         self.make_sequences()
         self.make_tables()
-        self.make_colliding_sequence()
         self.make_views()
         self.make_mviews()
         self.make_links_and_synonyms()


### PR DESCRIPTION
Second scheduled fuzz window (seeds 6090401-6090440): 3 of 40 rejected on PostgreSQL 16 and 18.

- **Generator (Oracle would refuse the estate):** a view took a table's name (Oracle's shared object namespace forbids it); a CONNECT BY compared BLOB with TIMESTAMP; a range partition's bounds exceeded what its NUMBER(5,10) key can hold. Views, sequences, and synonyms now keep out of the table namespace; hierarchies compare same-family columns; range keys must have room for their bounds.
- **Converter (legal on Oracle, rejected by PostgreSQL):** a numeric literal default the column cannot hold (NUMBER(5,10) DEFAULT -1) now declines by name with a note, like oversized string defaults do. A CONNECT BY whose PRIOR equality compares different type families (NUMBER against VARCHAR2 relies on Oracle's implicit conversion) declines with the reason.

Tests for both guards. The exact nightly window is re-run on this branch by workflow dispatch.