### PR TITLE
dev: a two-column range key must hold its second bound too

### DIFF
--- a/tools/fuzz_dump.py
+++ b/tools/fuzz_dump.py
@@ -1152,11 +1152,22 @@ class Estate:
                     (
                         c
                         for c in table.columns
-                        if c is not num and c.data_type in NUMERIC | TEXTUAL
+                        if c is not num
+                        and (
+                            c.data_type in TEXTUAL
+                            or (
+                                c.data_type in NUMERIC
+                                and (
+                                    c.precision is None
+                                    or c.precision - (c.scale or 0) >= 4
+                                )
+                            )
+                        )
                     ),
                     None,
                 )
                 if other is not None:
+                    # The second key must hold its bound too (ORA-14036).
                     key.append(other.name)
                     second = "200" if other.data_type in NUMERIC else "'X'"
                     parts = [


### PR DESCRIPTION
Third scheduled fuzz window (seeds 6090501-6090540): 1 of 40 rejected. A two-column range partition's second key, NUMBER(5,10), was given the bound 200, which Oracle refuses (ORA-14036). The generator now applies the same room rule to the second key that the first already had. Converter unchanged. The window is re-run on this branch by dispatch.